### PR TITLE
パブリッシュがうまくいかない問題を修正

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -41,6 +41,6 @@ jobs:
 
       - name: Publish to npm
         shell: bash
-        run: pnpm publish packages/components --access public --no-git-checks
+        run: pnpm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This pull request updates the npm publish command in the publish-npm.yml workflow file. The command now uses "pnpm publish" instead of "pnpm publish packages/components --access public --no-git-checks". This change simplifies the command and ensures that the package is published correctly.