### PR TITLE
package.jsonのexportsセクションを整理し、nodeおよびbrowserのエクスポートを明確に定義

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,33 +11,34 @@
   "type": "module",
   "exports": {
     ".": {
-      "default": "./dist/index.js",
-      "require": "./dist/index.cjs",
-      "import": "./dist/index.js",
       "types": "./dist/index.d.ts",
+      "node": {
+        "import": "./dist/index.js",
+        "require": "./dist/index.cjs"
+      },
       "browser": {
-        "require": "./dist/index.browser.cjs",
         "import": "./dist/index.browser.js",
-        "types": "./dist/index.browser.d.ts"
-      }
+        "require": "./dist/index.browser.cjs"
+      },
+      "default": "./dist/index.js"
     },
     "./browser": {
-      "default": "./dist/index.browser.js",
-      "require": "./dist/index.browser.cjs",
+      "types": "./dist/index.browser.d.ts",
       "import": "./dist/index.browser.js",
-      "types": "./dist/index.browser.d.ts"
+      "require": "./dist/index.browser.cjs",
+      "default": "./dist/index.browser.js"
+    },
+    "./utils/*": {
+      "types": "./dist/utils/*.d.ts",
+      "import": "./dist/utils/*.js",
+      "require": "./dist/utils/*.cjs",
+      "default": "./dist/utils/*.js"
     },
     "./*": {
-      "default": "./dist/*.js",
-      "require": "./dist/*.cjs",
+      "types": "./dist/*.d.ts",
       "import": "./dist/*.js",
-      "types": "./dist/*.d.ts"
-    },
-    "./utils": {
-      "default": "./dist/utils/*.js",
-      "require": "./dist/utils/*.cjs",
-      "import": "./dist/utils/*.js",
-      "types": "./dist/utils/*.d.ts"
+      "require": "./dist/*.cjs",
+      "default": "./dist/*.js"
     }
   },
   "main": "dist/index.cjs",


### PR DESCRIPTION
This pull request updates the `package.json` file to refine the module export structure, improving compatibility and clarity for different environments (Node.js, browser, and utilities). The changes reorganize and expand the export mappings to ensure proper handling of `import`, `require`, and `types` fields.

### Updates to export mappings in `package.json`:

* **Node.js-specific exports**: Introduced a `node` field under the main export to explicitly define `import` and `require` paths for Node.js environments.
* **Browser-specific exports**: Reorganized the `browser` field to remove the `types` field and ensure `require` and `import` paths are clearly defined.
* **Utility exports**: Added a new `./utils/*` export mapping to provide explicit paths for `types`, `import`, `require`, and `default` for utility files.
* **Default export reordering**: Moved the `default` field to the bottom of the main export mapping for better readability and logical grouping.
* **General cleanup**: Removed redundant or misplaced fields, such as duplicate `types` entries, and ensured consistency across all export mappings.