### PR TITLE
SearchBuilderR18のテストを追加

### DIFF
--- a/test/search-builder-r18.test.ts
+++ b/test/search-builder-r18.test.ts
@@ -1,0 +1,339 @@
+import {
+  beforeAll,
+  afterAll,
+  afterEach,
+  describe,
+  test,
+  expect,
+  vi,
+} from "vitest";
+import { setupServer } from "msw/node";
+import { responseGzipOrJson } from "./mock";
+import NarouAPI, {
+  OptionalFields,
+  R18Fields,
+  R18Site,
+} from "../src";
+import { http } from "msw";
+
+const server = setupServer();
+
+describe("SearchBuilderR18", () => {
+  beforeAll(() => server.listen());
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+
+  describe("execute", () => {
+    test("execute should call executeNovel18", async () => {
+      const mockFn = vi.fn();
+      server.use(
+        http.get("https://api.syosetu.com/novel18api/api/", ({ request }) => {
+          const url = new URL(request.url);
+          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
+          mockFn(url.searchParams.get("out"), url.searchParams.size);
+
+          return responseGzipOrJson(response, url);
+        })
+      );
+
+      const result = await NarouAPI.searchR18().execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].ncode).toBe("N1234AB");
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith("json", 2);
+    });
+  });
+
+  describe("r18Site", () => {
+    test("default", async () => {
+      const mockFn = vi.fn();
+      server.use(
+        http.get("https://api.syosetu.com/novel18api/api/", ({ request }) => {
+          const url = new URL(request.url);
+          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
+          mockFn(
+            url.searchParams.get("nocgenre"),
+            url.searchParams.get("out"),
+            url.searchParams.size
+          );
+
+          return responseGzipOrJson(response, url);
+        })
+      );
+
+      const result = await NarouAPI.searchR18().execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].ncode).toBe("N1234AB");
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(null, "json", 2);
+    });
+
+    test.each(Object.values(R18Site))("if r18Site = %i", async (site) => {
+      const mockFn = vi.fn();
+      server.use(
+        http.get("https://api.syosetu.com/novel18api/api/", ({ request }) => {
+          const url = new URL(request.url);
+          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
+          mockFn(
+            url.searchParams.get("nocgenre"),
+            url.searchParams.get("out"),
+            url.searchParams.size
+          );
+
+          return responseGzipOrJson(response, url);
+        })
+      );
+
+      const result = await NarouAPI.searchR18().r18Site(site).execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].ncode).toBe("N1234AB");
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(site.toString(), "json", 3);
+    });
+
+    test("if r18Site = [1, 2, 3]", async () => {
+      const mockFn = vi.fn();
+      server.use(
+        http.get("https://api.syosetu.com/novel18api/api/", ({ request }) => {
+          const url = new URL(request.url);
+          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
+          mockFn(
+            url.searchParams.get("nocgenre"),
+            url.searchParams.get("out"),
+            url.searchParams.size
+          );
+
+          return responseGzipOrJson(response, url);
+        })
+      );
+
+      const result = await NarouAPI.searchR18()
+        .r18Site([R18Site.Nocturne, R18Site.MoonLight, R18Site.MoonLightBL])
+        .execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].ncode).toBe("N1234AB");
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith("1-2-3", "json", 3);
+    });
+  });
+
+  describe("xid", () => {
+    test("default", async () => {
+      const mockFn = vi.fn();
+      server.use(
+        http.get("https://api.syosetu.com/novel18api/api/", ({ request }) => {
+          const url = new URL(request.url);
+          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
+          mockFn(
+            url.searchParams.get("xid"),
+            url.searchParams.get("out"),
+            url.searchParams.size
+          );
+
+          return responseGzipOrJson(response, url);
+        })
+      );
+
+      const result = await NarouAPI.searchR18().execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].ncode).toBe("N1234AB");
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(null, "json", 2);
+    });
+
+    test.each([123, 456, 789])("if xid = %i", async (id) => {
+      const mockFn = vi.fn();
+      server.use(
+        http.get("https://api.syosetu.com/novel18api/api/", ({ request }) => {
+          const url = new URL(request.url);
+          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
+          mockFn(
+            url.searchParams.get("xid"),
+            url.searchParams.get("out"),
+            url.searchParams.size
+          );
+
+          return responseGzipOrJson(response, url);
+        })
+      );
+
+      const result = await NarouAPI.searchR18().xid(id).execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].ncode).toBe("N1234AB");
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(id.toString(), "json", 3);
+    });
+
+    test("if xid = [123, 456, 789]", async () => {
+      const mockFn = vi.fn();
+      server.use(
+        http.get("https://api.syosetu.com/novel18api/api/", ({ request }) => {
+          const url = new URL(request.url);
+          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
+          mockFn(
+            url.searchParams.get("xid"),
+            url.searchParams.get("out"),
+            url.searchParams.size
+          );
+
+          return responseGzipOrJson(response, url);
+        })
+      );
+
+      const result = await NarouAPI.searchR18().xid([123, 456, 789]).execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].ncode).toBe("N1234AB");
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith("123-456-789", "json", 3);
+    });
+  });
+
+  describe("fields", () => {
+    test("default", async () => {
+      const mockFn = vi.fn();
+      server.use(
+        http.get("https://api.syosetu.com/novel18api/api/", ({ request }) => {
+          const url = new URL(request.url);
+          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
+          mockFn(
+            url.searchParams.get("of"),
+            url.searchParams.get("out"),
+            url.searchParams.size
+          );
+
+          return responseGzipOrJson(response, url);
+        })
+      );
+
+      const result = await NarouAPI.searchR18().execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].ncode).toBe("N1234AB");
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(null, "json", 2);
+    });
+
+    test("if fields = R18Fields.title", async () => {
+      const mockFn = vi.fn();
+      server.use(
+        http.get("https://api.syosetu.com/novel18api/api/", ({ request }) => {
+          const url = new URL(request.url);
+          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
+          mockFn(
+            url.searchParams.get("of"),
+            url.searchParams.get("out"),
+            url.searchParams.size
+          );
+
+          return responseGzipOrJson(response, url);
+        })
+      );
+
+      const result = await NarouAPI.searchR18()
+        .fields(R18Fields.title)
+        .execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].ncode).toBe("N1234AB");
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith("t", "json", 3);
+    });
+
+    test("if fields = [R18Fields.title, R18Fields.ncode]", async () => {
+      const mockFn = vi.fn();
+      server.use(
+        http.get("https://api.syosetu.com/novel18api/api/", ({ request }) => {
+          const url = new URL(request.url);
+          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
+          mockFn(
+            url.searchParams.get("of"),
+            url.searchParams.get("out"),
+            url.searchParams.size
+          );
+
+          return responseGzipOrJson(response, url);
+        })
+      );
+
+      const result = await NarouAPI.searchR18()
+        .fields([R18Fields.title, R18Fields.ncode])
+        .execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].ncode).toBe("N1234AB");
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith("t-n", "json", 3);
+    });
+  });
+
+  describe("opt", () => {
+    test("default", async () => {
+      const mockFn = vi.fn();
+      server.use(
+        http.get("https://api.syosetu.com/novel18api/api/", ({ request }) => {
+          const url = new URL(request.url);
+          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
+          mockFn(
+            url.searchParams.get("opt"),
+            url.searchParams.get("out"),
+            url.searchParams.size
+          );
+
+          return responseGzipOrJson(response, url);
+        })
+      );
+
+      const result = await NarouAPI.searchR18().execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].ncode).toBe("N1234AB");
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(null, "json", 2);
+    });
+
+    test("if opt = OptionalFields.weekly_unique", async () => {
+      const mockFn = vi.fn();
+      server.use(
+        http.get("https://api.syosetu.com/novel18api/api/", ({ request }) => {
+          const url = new URL(request.url);
+          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
+          mockFn(
+            url.searchParams.get("opt"),
+            url.searchParams.get("out"),
+            url.searchParams.size
+          );
+
+          return responseGzipOrJson(response, url);
+        })
+      );
+
+      const result = await NarouAPI.searchR18()
+        .opt(OptionalFields.weekly_unique)
+        .execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].ncode).toBe("N1234AB");
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith("weekly", "json", 3);
+    });
+  });
+});

--- a/test/search-builder-r18.test.ts
+++ b/test/search-builder-r18.test.ts
@@ -18,6 +18,24 @@ import { http } from "msw";
 
 const server = setupServer();
 
+const setupMockHandler = (
+  mockFn: (...args: unknown[]) => void,
+  watchParams: string[] = ["out"]
+) => {
+  server.use(
+    http.get("https://api.syosetu.com/novel18api/api/", ({ request }) => {
+      const url = new URL(request.url);
+      const params = url.searchParams;
+      const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
+
+      const values = watchParams.map(param => params.get(param));
+      mockFn(...values, params.size);
+
+      return responseGzipOrJson(response, url);
+    })
+  );
+};
+
 describe("SearchBuilderR18", () => {
   beforeAll(() => server.listen());
   afterEach(() => server.resetHandlers());
@@ -26,15 +44,7 @@ describe("SearchBuilderR18", () => {
   describe("execute", () => {
     test("execute should call executeNovel18", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novel18api/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(url.searchParams.get("out"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["out"]);
 
       const result = await NarouAPI.searchR18().execute();
       expect(result.allcount).toBe(1);
@@ -49,19 +59,7 @@ describe("SearchBuilderR18", () => {
   describe("r18Site", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novel18api/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("nocgenre"),
-            url.searchParams.get("out"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["nocgenre", "out"]);
 
       const result = await NarouAPI.searchR18().execute();
       expect(result.allcount).toBe(1);
@@ -74,19 +72,7 @@ describe("SearchBuilderR18", () => {
 
     test.each(Object.values(R18Site))("if r18Site = %i", async (site) => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novel18api/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("nocgenre"),
-            url.searchParams.get("out"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["nocgenre", "out"]);
 
       const result = await NarouAPI.searchR18().r18Site(site).execute();
       expect(result.allcount).toBe(1);
@@ -99,19 +85,7 @@ describe("SearchBuilderR18", () => {
 
     test("if r18Site = [1, 2, 3]", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novel18api/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("nocgenre"),
-            url.searchParams.get("out"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["nocgenre", "out"]);
 
       const result = await NarouAPI.searchR18()
         .r18Site([R18Site.Nocturne, R18Site.MoonLight, R18Site.MoonLightBL])
@@ -128,19 +102,7 @@ describe("SearchBuilderR18", () => {
   describe("xid", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novel18api/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("xid"),
-            url.searchParams.get("out"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["xid", "out"]);
 
       const result = await NarouAPI.searchR18().execute();
       expect(result.allcount).toBe(1);
@@ -153,19 +115,7 @@ describe("SearchBuilderR18", () => {
 
     test.each([123, 456, 789])("if xid = %i", async (id) => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novel18api/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("xid"),
-            url.searchParams.get("out"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["xid", "out"]);
 
       const result = await NarouAPI.searchR18().xid(id).execute();
       expect(result.allcount).toBe(1);
@@ -178,19 +128,7 @@ describe("SearchBuilderR18", () => {
 
     test("if xid = [123, 456, 789]", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novel18api/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("xid"),
-            url.searchParams.get("out"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["xid", "out"]);
 
       const result = await NarouAPI.searchR18().xid([123, 456, 789]).execute();
       expect(result.allcount).toBe(1);
@@ -205,19 +143,7 @@ describe("SearchBuilderR18", () => {
   describe("fields", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novel18api/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("of"),
-            url.searchParams.get("out"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["of", "out"]);
 
       const result = await NarouAPI.searchR18().execute();
       expect(result.allcount).toBe(1);
@@ -230,19 +156,7 @@ describe("SearchBuilderR18", () => {
 
     test("if fields = R18Fields.title", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novel18api/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("of"),
-            url.searchParams.get("out"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["of", "out"]);
 
       const result = await NarouAPI.searchR18()
         .fields(R18Fields.title)
@@ -257,19 +171,7 @@ describe("SearchBuilderR18", () => {
 
     test("if fields = [R18Fields.title, R18Fields.ncode]", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novel18api/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("of"),
-            url.searchParams.get("out"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["of", "out"]);
 
       const result = await NarouAPI.searchR18()
         .fields([R18Fields.title, R18Fields.ncode])
@@ -286,19 +188,7 @@ describe("SearchBuilderR18", () => {
   describe("opt", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novel18api/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("opt"),
-            url.searchParams.get("out"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["opt", "out"]);
 
       const result = await NarouAPI.searchR18().execute();
       expect(result.allcount).toBe(1);
@@ -311,19 +201,7 @@ describe("SearchBuilderR18", () => {
 
     test("if opt = OptionalFields.weekly_unique", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novel18api/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("opt"),
-            url.searchParams.get("out"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["opt", "out"]);
 
       const result = await NarouAPI.searchR18()
         .opt(OptionalFields.weekly_unique)

--- a/test/search-builder.test.ts
+++ b/test/search-builder.test.ts
@@ -24,6 +24,24 @@ import { http } from "msw";
 
 const server = setupServer();
 
+const setupMockHandler = (
+  mockFn: (...args: unknown[]) => void,
+  watchParams: string[] = ["out"]
+) => {
+  server.use(
+    http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
+      const url = new URL(request.url);
+      const params = url.searchParams;
+      const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
+
+      const values = watchParams.map(param => params.get(param));
+      mockFn(...values, params.size);
+
+      return responseGzipOrJson(response, url);
+    })
+  );
+};
+
 describe("SearchBuilder", () => {
   beforeAll(() => server.listen());
   afterEach(() => server.resetHandlers());
@@ -32,19 +50,7 @@ describe("SearchBuilder", () => {
   describe("gzip", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("gzip"),
-            url.searchParams.get("out"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBe(1);
       expect(result.length).toBe(1);
@@ -56,19 +62,7 @@ describe("SearchBuilder", () => {
 
     test("if gzip = 0", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("gzip"),
-            url.searchParams.get("out"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["out"]);
 
       const result = await NarouAPI.search().gzip(0).execute();
       expect(result.allcount).toBe(1);
@@ -76,24 +70,12 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      expect(mockFn).toHaveBeenCalledWith(null, "json", 1);
+      expect(mockFn).toHaveBeenCalledWith("json", 1);
     });
 
     test.each([1, 2, 3, 4, 5] as const)("if gzip = %i", async (gzip) => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("gzip"),
-            url.searchParams.get("out"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().gzip(gzip).execute();
       expect(result.allcount).toBe(1);
@@ -108,19 +90,7 @@ describe("SearchBuilder", () => {
   describe("limit", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("lim"),
-            url.searchParams.get("out"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBe(1);
@@ -128,25 +98,12 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipがついているのでsizeが2になる
-      expect(mockFn).toHaveBeenCalledWith(null, "json", 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     test.each([1, 10, 100, 500] as const)("if limit = %i", async (limit) => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("lim"),
-            url.searchParams.get("out"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["lim", "gzip", "out"]);
 
       const result = await NarouAPI.search().limit(limit).execute();
       expect(result.allcount).toBe(1);
@@ -154,27 +111,14 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(limit.toString(), "json", 3);
+      expect(mockFn).toHaveBeenCalledWith(limit.toString(), "5", "json", 3);
     });
   });
 
   describe("start", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("start"),
-            url.searchParams.get("out"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBe(1);
@@ -182,25 +126,12 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipがついているのでsizeが2になる
-      expect(mockFn).toHaveBeenCalledWith(null, "json", 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     test.each([1, 10, 100, 500] as const)("if start = %i", async (start) => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("st"),
-            url.searchParams.get("out"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["st", "gzip", "out"]);
 
       const result = await NarouAPI.search().start(start).execute();
       expect(result.allcount).toBe(1);
@@ -208,40 +139,26 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(start.toString(), "json", 3);
+      expect(mockFn).toHaveBeenCalledWith(start.toString(), "5", "json", 3);
     });
   });
 
   describe("page", () => {
     describe("default count", () => {
-      test.each([1, 2, 3, 4, 5] as const)("if page = %i", async (count) => {
+      test.each([1, 2, 3, 4, 5] as const)("if page = %i", async (page) => {
         const mockFn = vi.fn();
-        server.use(
-          http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-            const url = new URL(request.url);
-            const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-            mockFn(
-              url.searchParams.get("lim"),
-              url.searchParams.get("st"),
-              url.searchParams.get("out"),
-              url.searchParams.size
-            );
+        setupMockHandler(mockFn, ["lim", "st", "gzip", "out"]);
 
-            return responseGzipOrJson(response, url);
-          })
-        );
-
-        const result = await NarouAPI.search().page(count).execute();
+        const result = await NarouAPI.search().page(page).execute();
         expect(result.allcount).toBe(1);
         expect(result.length).toBe(1);
         expect(result.values).toHaveLength(1);
         expect(result.values[0].ncode).toBe("N1234AB");
         expect(mockFn).toHaveBeenCalledTimes(1);
-        // MEMO: gzipがついているのでsizeが4になる
         expect(mockFn).toHaveBeenCalledWith(
           "20",
-          (count * 20).toString(),
+          (page * 20).toString(),
+          "5",
           "json",
           4
         );
@@ -249,22 +166,9 @@ describe("SearchBuilder", () => {
     });
 
     describe.each([1, 10, 100, 500] as const)("if count = %i", (count) => {
-      test.each([1, 2, 3, 4, 5] as const)("if count = %i", async (page) => {
+      test.each([1, 2, 3, 4, 5] as const)("if page = %i", async (page) => {
         const mockFn = vi.fn();
-        server.use(
-          http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-            const url = new URL(request.url);
-            const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-            mockFn(
-              url.searchParams.get("lim"),
-              url.searchParams.get("st"),
-              url.searchParams.get("out"),
-              url.searchParams.size
-            );
-
-            return responseGzipOrJson(response, url);
-          })
-        );
+        setupMockHandler(mockFn, ["lim", "st", "gzip", "out"]);
 
         const result = await NarouAPI.search().page(page, count).execute();
         expect(result.allcount).toBe(1);
@@ -272,10 +176,10 @@ describe("SearchBuilder", () => {
         expect(result.values).toHaveLength(1);
         expect(result.values[0].ncode).toBe("N1234AB");
         expect(mockFn).toHaveBeenCalledTimes(1);
-        // MEMO: gzipがついているのでsizeが4になる
         expect(mockFn).toHaveBeenCalledWith(
           count.toString(),
           (page * count).toString(),
+          "5",
           "json",
           4
         );
@@ -286,15 +190,7 @@ describe("SearchBuilder", () => {
   describe("order", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(url.searchParams.get("order"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBe(1);
@@ -302,22 +198,13 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipがついているのでsizeが2になる
-      expect(mockFn).toHaveBeenCalledWith(null, 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     describe.each(Object.values(Order))("if order = %s", (order) => {
       test(order, async () => {
         const mockFn = vi.fn();
-        server.use(
-          http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-            const url = new URL(request.url);
-            const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-            mockFn(url.searchParams.get("order"), url.searchParams.size);
-
-            return responseGzipOrJson(response, url);
-          })
-        );
+        setupMockHandler(mockFn, ["order", "gzip", "out"]);
 
         const result = await NarouAPI.search().order(order).execute();
         expect(result.allcount).toBe(1);
@@ -325,8 +212,7 @@ describe("SearchBuilder", () => {
         expect(result.values).toHaveLength(1);
         expect(result.values[0].ncode).toBe("N1234AB");
         expect(mockFn).toHaveBeenCalledTimes(1);
-        // MEMO: gzipとoutがついているのでsizeが3になる
-        expect(mockFn).toHaveBeenCalledWith(order, 3);
+        expect(mockFn).toHaveBeenCalledWith(order, "5", "json", 3);
       });
     });
   });
@@ -334,15 +220,7 @@ describe("SearchBuilder", () => {
   describe("word", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(url.searchParams.get("word"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBe(1);
@@ -350,23 +228,14 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが2になる
-      expect(mockFn).toHaveBeenCalledWith(null, 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     test.each(["test", "テスト", "1234", "あいう"])(
       "if word = %s",
       async (word) => {
         const mockFn = vi.fn();
-        server.use(
-          http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-            const url = new URL(request.url);
-            const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-            mockFn(url.searchParams.get("word"), url.searchParams.size);
-
-            return responseGzipOrJson(response, url);
-          })
-        );
+        setupMockHandler(mockFn, ["word", "gzip", "out"]);
 
         const result = await NarouAPI.search().word(word).execute();
         expect(result.allcount).toBe(1);
@@ -374,8 +243,7 @@ describe("SearchBuilder", () => {
         expect(result.values).toHaveLength(1);
         expect(result.values[0].ncode).toBe("N1234AB");
         expect(mockFn).toHaveBeenCalledTimes(1);
-        // MEMO: gzipとoutがついているのでsizeが3になる
-        expect(mockFn).toHaveBeenCalledWith(word, 3);
+        expect(mockFn).toHaveBeenCalledWith(word, "5", "json", 3);
       }
     );
   });
@@ -383,15 +251,7 @@ describe("SearchBuilder", () => {
   describe("notWord", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(url.searchParams.get("notword"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBe(1);
@@ -399,23 +259,14 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが2になる
-      expect(mockFn).toHaveBeenCalledWith(null, 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     test.each(["test", "テスト", "1234", "あいう"])(
       "if not word = %s",
       async (word) => {
         const mockFn = vi.fn();
-        server.use(
-          http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-            const url = new URL(request.url);
-            const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-            mockFn(url.searchParams.get("notword"), url.searchParams.size);
-
-            return responseGzipOrJson(response, url);
-          })
-        );
+        setupMockHandler(mockFn, ["notword", "gzip", "out"]);
 
         const result = await NarouAPI.search().notWord(word).execute();
         expect(result.allcount).toBe(1);
@@ -423,8 +274,7 @@ describe("SearchBuilder", () => {
         expect(result.values).toHaveLength(1);
         expect(result.values[0].ncode).toBe("N1234AB");
         expect(mockFn).toHaveBeenCalledTimes(1);
-        // MEMO: gzipとoutがついているのでsizeが3になる
-        expect(mockFn).toHaveBeenCalledWith(word, 3);
+        expect(mockFn).toHaveBeenCalledWith(word, "5", "json", 3);
       }
     );
   });
@@ -432,15 +282,7 @@ describe("SearchBuilder", () => {
   describe("byTitle", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(url.searchParams.get("title"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBe(1);
@@ -448,21 +290,12 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが2になる
-      expect(mockFn).toHaveBeenCalledWith(null, 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     test("if byTitle = true", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(url.searchParams.get("title"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["title", "gzip", "out"]);
 
       const result = await NarouAPI.search().byTitle().execute();
       expect(result.allcount).toBe(1);
@@ -470,21 +303,12 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(BooleanNumber.True.toString(), 3);
+      expect(mockFn).toHaveBeenCalledWith(BooleanNumber.True.toString(), "5", "json", 3);
     });
 
     test("if byTitle = false", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(url.searchParams.get("title"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["title", "gzip", "out"]);
 
       const result = await NarouAPI.search().byTitle(false).execute();
       expect(result.allcount).toBe(1);
@@ -492,23 +316,14 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(BooleanNumber.False.toString(), 3);
+      expect(mockFn).toHaveBeenCalledWith(BooleanNumber.False.toString(), "5", "json", 3);
     });
   });
 
   describe("byOutline", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(url.searchParams.get("ex"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBe(1);
@@ -516,21 +331,12 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが2になる
-      expect(mockFn).toHaveBeenCalledWith(null, 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     test("if byOutline = true", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(url.searchParams.get("ex"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["ex", "gzip", "out"]);
 
       const result = await NarouAPI.search().byOutline().execute();
       expect(result.allcount).toBe(1);
@@ -538,21 +344,12 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(BooleanNumber.True.toString(), 3);
+      expect(mockFn).toHaveBeenCalledWith(BooleanNumber.True.toString(), "5", "json", 3);
     });
 
     test("if byOutline = false", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(url.searchParams.get("ex"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["ex", "gzip", "out"]);
 
       const result = await NarouAPI.search().byOutline(false).execute();
       expect(result.allcount).toBe(1);
@@ -560,23 +357,14 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(BooleanNumber.False.toString(), 3);
+      expect(mockFn).toHaveBeenCalledWith(BooleanNumber.False.toString(), "5", "json", 3);
     });
   });
 
   describe("byKeyword", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(url.searchParams.get("keyword"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBe(1);
@@ -584,21 +372,12 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが2になる
-      expect(mockFn).toHaveBeenCalledWith(null, 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     test("if byKeyword = true", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(url.searchParams.get("keyword"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["keyword", "gzip", "out"]);
 
       const result = await NarouAPI.search().byKeyword().execute();
       expect(result.allcount).toBe(1);
@@ -606,21 +385,12 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(BooleanNumber.True.toString(), 3);
+      expect(mockFn).toHaveBeenCalledWith(BooleanNumber.True.toString(), "5", "json", 3);
     });
 
     test("if byKeyword = false", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(url.searchParams.get("keyword"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["keyword", "gzip", "out"]);
 
       const result = await NarouAPI.search().byKeyword(false).execute();
       expect(result.allcount).toBe(1);
@@ -628,23 +398,14 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(BooleanNumber.False.toString(), 3);
+      expect(mockFn).toHaveBeenCalledWith(BooleanNumber.False.toString(), "5", "json", 3);
     });
   });
 
   describe("byAuthor", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(url.searchParams.get("wname"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBe(1);
@@ -652,21 +413,12 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが2になる
-      expect(mockFn).toHaveBeenCalledWith(null, 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     test("if byAuthor = true", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(url.searchParams.get("wname"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["wname", "gzip", "out"]);
 
       const result = await NarouAPI.search().byAuthor().execute();
       expect(result.allcount).toBe(1);
@@ -674,21 +426,12 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(BooleanNumber.True.toString(), 3);
+      expect(mockFn).toHaveBeenCalledWith(BooleanNumber.True.toString(), "5", "json", 3);
     });
 
     test("if byAuthor = false", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(url.searchParams.get("wname"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["wname", "gzip", "out"]);
 
       const result = await NarouAPI.search().byAuthor(false).execute();
       expect(result.allcount).toBe(1);
@@ -696,27 +439,14 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(BooleanNumber.False.toString(), 3);
+      expect(mockFn).toHaveBeenCalledWith(BooleanNumber.False.toString(), "5", "json", 3);
     });
   });
 
   describe("isBL", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("isbl"),
-            url.searchParams.get("notbl"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBe(1);
@@ -724,25 +454,12 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが2になる
-      expect(mockFn).toHaveBeenCalledWith(null, null, 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     test("if isBL = true", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("isbl"),
-            url.searchParams.get("notbl"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["isbl", "gzip", "out"]);
 
       const result = await NarouAPI.search().isBL().execute();
       expect(result.allcount).toBe(1);
@@ -750,29 +467,17 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
       expect(mockFn).toHaveBeenCalledWith(
         BooleanNumber.True.toString(),
-        null,
+        "5",
+        "json",
         3
       );
     });
 
     test("if isBL = false", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("isbl"),
-            url.searchParams.get("notbl"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["notbl", "gzip", "out"]);
 
       const result = await NarouAPI.search().isBL(false).execute();
       expect(result.allcount).toBe(1);
@@ -780,10 +485,10 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
       expect(mockFn).toHaveBeenCalledWith(
-        null,
         BooleanNumber.True.toString(),
+        "5",
+        "json",
         3
       );
     });
@@ -792,19 +497,7 @@ describe("SearchBuilder", () => {
   describe("isGL", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("isgl"),
-            url.searchParams.get("notgl"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBe(1);
@@ -812,25 +505,12 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが2になる
-      expect(mockFn).toHaveBeenCalledWith(null, null, 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     test("if isGL = true", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("isgl"),
-            url.searchParams.get("notgl"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["isgl", "gzip", "out"]);
 
       const result = await NarouAPI.search().isGL().execute();
       expect(result.allcount).toBe(1);
@@ -838,29 +518,17 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
       expect(mockFn).toHaveBeenCalledWith(
         BooleanNumber.True.toString(),
-        null,
+        "5",
+        "json",
         3
       );
     });
 
     test("if isGL = false", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("isgl"),
-            url.searchParams.get("notgl"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["notgl", "gzip", "out"]);
 
       const result = await NarouAPI.search().isGL(false).execute();
       expect(result.allcount).toBe(1);
@@ -868,10 +536,10 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
       expect(mockFn).toHaveBeenCalledWith(
-        null,
         BooleanNumber.True.toString(),
+        "5",
+        "json",
         3
       );
     });
@@ -880,19 +548,7 @@ describe("SearchBuilder", () => {
   describe("isZankoku", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("iszankoku"),
-            url.searchParams.get("notzankoku"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBe(1);
@@ -900,25 +556,12 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが2になる
-      expect(mockFn).toHaveBeenCalledWith(null, null, 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     test("if isZankoku = true", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("iszankoku"),
-            url.searchParams.get("notzankoku"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["iszankoku", "gzip", "out"]);
 
       const result = await NarouAPI.search().isZankoku().execute();
       expect(result.allcount).toBe(1);
@@ -926,29 +569,17 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
       expect(mockFn).toHaveBeenCalledWith(
         BooleanNumber.True.toString(),
-        null,
+        "5",
+        "json",
         3
       );
     });
 
     test("if isZankoku = false", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("iszankoku"),
-            url.searchParams.get("notzankoku"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["notzankoku", "gzip", "out"]);
 
       const result = await NarouAPI.search().isZankoku(false).execute();
       expect(result.allcount).toBe(1);
@@ -956,10 +587,10 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
       expect(mockFn).toHaveBeenCalledWith(
-        null,
         BooleanNumber.True.toString(),
+        "5",
+        "json",
         3
       );
     });
@@ -968,19 +599,7 @@ describe("SearchBuilder", () => {
   describe("isTensei", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("istensei"),
-            url.searchParams.get("nottensei"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBe(1);
@@ -988,25 +607,12 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが2になる
-      expect(mockFn).toHaveBeenCalledWith(null, null, 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     test("if isTensei = true", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("istensei"),
-            url.searchParams.get("nottensei"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["istensei", "gzip", "out"]);
 
       const result = await NarouAPI.search().isTensei().execute();
       expect(result.allcount).toBe(1);
@@ -1014,29 +620,17 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
       expect(mockFn).toHaveBeenCalledWith(
         BooleanNumber.True.toString(),
-        null,
+        "5",
+        "json",
         3
       );
     });
 
     test("if isTensei = false", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("istensei"),
-            url.searchParams.get("nottensei"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["nottensei", "gzip", "out"]);
 
       const result = await NarouAPI.search().isTensei(false).execute();
       expect(result.allcount).toBe(1);
@@ -1044,10 +638,10 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
       expect(mockFn).toHaveBeenCalledWith(
-        null,
         BooleanNumber.True.toString(),
+        "5",
+        "json",
         3
       );
     });
@@ -1056,19 +650,7 @@ describe("SearchBuilder", () => {
   describe("isTenni", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("istenni"),
-            url.searchParams.get("nottenni"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBe(1);
@@ -1076,25 +658,12 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが2になる
-      expect(mockFn).toHaveBeenCalledWith(null, null, 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     test("if isTenni = true", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("istenni"),
-            url.searchParams.get("nottenni"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["istenni", "gzip", "out"]);
 
       const result = await NarouAPI.search().isTenni().execute();
       expect(result.allcount).toBe(1);
@@ -1102,29 +671,17 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
       expect(mockFn).toHaveBeenCalledWith(
         BooleanNumber.True.toString(),
-        null,
+        "5",
+        "json",
         3
       );
     });
 
     test("if isTenni = false", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("istenni"),
-            url.searchParams.get("nottenni"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["nottenni", "gzip", "out"]);
 
       const result = await NarouAPI.search().isTenni(false).execute();
       expect(result.allcount).toBe(1);
@@ -1132,10 +689,10 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
       expect(mockFn).toHaveBeenCalledWith(
-        null,
         BooleanNumber.True.toString(),
+        "5",
+        "json",
         3
       );
     });
@@ -1144,19 +701,7 @@ describe("SearchBuilder", () => {
   describe("isTT", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(
-            url.searchParams.get("istt"),
-            url.searchParams.get("nottt"),
-            url.searchParams.size
-          );
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBe(1);
@@ -1164,21 +709,12 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが2になる
-      expect(mockFn).toHaveBeenCalledWith(null, null, 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     test("if set isTT", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }, { ncode: "N1234AB" }];
-          mockFn(url.searchParams.get("istt"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["istt", "gzip", "out"]);
 
       const result = await NarouAPI.search().isTT().execute();
       expect(result.allcount).toBe(1);
@@ -1186,109 +722,61 @@ describe("SearchBuilder", () => {
       expect(result.values).toHaveLength(1);
       expect(result.values[0].ncode).toBe("N1234AB");
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(BooleanNumber.True.toString(), 3);
+      expect(mockFn).toHaveBeenCalledWith(BooleanNumber.True.toString(), "5", "json", 3);
     });
   });
 
   describe("length", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("length"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが2になる
-      expect(mockFn).toHaveBeenCalledWith(null, 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     test.each([1, 10, 100])("if length = %i", async (length) => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("length"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["length", "gzip", "out"]);
 
       const result = await NarouAPI.search().length(length).execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(length.toString(), 3);
+      expect(mockFn).toHaveBeenCalledWith(length.toString(), "5", "json", 3);
     });
 
     test.each([1000, 10000, 100000])("if length = `0-%i`", async (length) => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("length"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["length", "gzip", "out"]);
 
       const result = await NarouAPI.search().length([0, length]).execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(`0-${length}`, 3);
+      expect(mockFn).toHaveBeenCalledWith(`0-${length}`, "5", "json", 3);
     });
   });
 
   describe("kaiwaritu", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("kaiwaritu"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが2になる
-      expect(mockFn).toHaveBeenCalledWith(null, 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     test.each([1, 10, 100])("if kaiwaritu = %i", async (kaiwaritu) => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("kaiwaritu"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["kaiwaritu", "gzip", "out"]);
 
       const result = await NarouAPI.search().kaiwaritu(kaiwaritu).execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(kaiwaritu.toString(), 3);
+      expect(mockFn).toHaveBeenCalledWith(kaiwaritu.toString(), "5", "json", 3);
     });
 
     test.each([
@@ -1297,64 +785,34 @@ describe("SearchBuilder", () => {
       [20, 30],
     ])("if kaiwaritu = `%i-%i`", async (min, max) => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("kaiwaritu"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["kaiwaritu", "gzip", "out"]);
 
       const result = await NarouAPI.search().kaiwaritu(min, max).execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(`${min}-${max}`, 3);
+      expect(mockFn).toHaveBeenCalledWith(`${min}-${max}`, "5", "json", 3);
     });
   });
 
   describe("sasie", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("sasie"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが2になる
-      expect(mockFn).toHaveBeenCalledWith(null, 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     test.each([1, 10, 100])("if sasie = %i", async (sasie) => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("sasie"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["sasie", "gzip", "out"]);
 
       const result = await NarouAPI.search().sasie(sasie).execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(sasie.toString(), 3);
+      expect(mockFn).toHaveBeenCalledWith(sasie.toString(), "5", "json", 3);
     });
 
     test.each([
@@ -1363,64 +821,34 @@ describe("SearchBuilder", () => {
       [20, 30],
     ])("if sasie = `%i-%i`", async (min, max) => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("sasie"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["sasie", "gzip", "out"]);
 
       const result = await NarouAPI.search().sasie([min, max]).execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(`${min}-${max}`, 3);
+      expect(mockFn).toHaveBeenCalledWith(`${min}-${max}`, "5", "json", 3);
     });
   });
 
   describe("time", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("time"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが2になる
-      expect(mockFn).toHaveBeenCalledWith(null, 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     test.each([1, 10, 100])("if time = %i", async (time) => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("time"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["time", "gzip", "out"]);
 
       const result = await NarouAPI.search().time(time).execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(time.toString(), 3);
+      expect(mockFn).toHaveBeenCalledWith(time.toString(), "5", "json", 3);
     });
 
     test.each([
@@ -1429,182 +857,98 @@ describe("SearchBuilder", () => {
       [20, 30],
     ])("if time = `%i-%i`", async (min, max) => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("time"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["time", "gzip", "out"]);
 
       const result = await NarouAPI.search().time([min, max]).execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(`${min}-${max}`, 3);
+      expect(mockFn).toHaveBeenCalledWith(`${min}-${max}`, "5", "json", 3);
     });
   });
 
   describe("ncode", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("ncode"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBeGreaterThanOrEqual(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが2になる
-      expect(mockFn).toHaveBeenCalledWith(null, 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     test.each(["N1234AB", "N5678CD", "N9012EF"])(
       "if ncode = %s",
       async (ncode) => {
         const mockFn = vi.fn();
-        server.use(
-          http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-            const url = new URL(request.url);
-
-            const response = [{ allcount: 1 }];
-            mockFn(url.searchParams.get("ncode"), url.searchParams.size);
-
-            return responseGzipOrJson(response, url);
-          })
-        );
+        setupMockHandler(mockFn, ["ncode", "gzip", "out"]);
 
         const result = await NarouAPI.search().ncode(ncode).execute();
         expect(result.allcount).toBe(1);
         expect(mockFn).toHaveBeenCalledTimes(1);
-        // MEMO: gzipとoutがついているのでsizeが3になる
-        expect(mockFn).toHaveBeenCalledWith(ncode, 3);
+        expect(mockFn).toHaveBeenCalledWith(ncode, "5", "json", 3);
       }
     );
 
     test("if ncode = `N1234AB`, `N5678CD`, `N9012EF`", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-
-          const response = [{ allcount: 3 }];
-          mockFn(url.searchParams.get("ncode"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["ncode", "gzip", "out"]);
 
       const result = await NarouAPI.search()
         .ncode(["N1234AB", "N5678CD", "N9012EF"])
         .execute();
-      expect(result.allcount).toBe(3);
+      expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith("N1234AB-N5678CD-N9012EF", 3);
+      expect(mockFn).toHaveBeenCalledWith("N1234AB-N5678CD-N9012EF", "5", "json", 3);
     });
   });
 
   describe("type", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("type"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが2になる
-      expect(mockFn).toHaveBeenCalledWith(null, 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     test.each(Object.values(NovelTypeParam))("if type = %s", async (type) => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("type"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["type", "gzip", "out"]);
 
       const result = await NarouAPI.search().type(type).execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(type, 3);
+      expect(mockFn).toHaveBeenCalledWith(type, "5", "json", 3);
     });
   });
 
   describe("buntai", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("buntai"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが2になる
-      expect(mockFn).toHaveBeenCalledWith(null, 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     test.each(Object.values(BuntaiParam))("if buntai = %i", async (buntai) => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("buntai"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["buntai", "gzip", "out"]);
 
       const result = await NarouAPI.search().buntai(buntai).execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(buntai.toString(), 3);
+      expect(mockFn).toHaveBeenCalledWith(buntai.toString(), "5", "json", 3);
     });
 
     test("if buntai = `1-2-4-6`", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 3 }];
-          mockFn(url.searchParams.get("buntai"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["buntai", "gzip", "out"]);
 
       const result = await NarouAPI.search()
         .buntai([
@@ -1614,153 +958,85 @@ describe("SearchBuilder", () => {
           BuntaiParam.JisageKaigyoHutsuu,
         ])
         .execute();
-      expect(result.allcount).toBe(3);
+      expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith("1-2-4-6", 3);
+      expect(mockFn).toHaveBeenCalledWith("1-2-4-6", "5", "json", 3);
     });
   });
 
   describe("isStop", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("stop"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが2になる
-      expect(mockFn).toHaveBeenCalledWith(null, 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     test("if isStop = true", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("stop"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["stop", "gzip", "out"]);
 
       const result = await NarouAPI.search().isStop().execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(StopParam.Stopping.toString(), 3);
+      expect(mockFn).toHaveBeenCalledWith(StopParam.Stopping.toString(), "5", "json", 3);
     });
 
     test("if isStop = false", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("stop"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["stop", "gzip", "out"]);
 
       const result = await NarouAPI.search().isStop(false).execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(StopParam.NoStopping.toString(), 3);
+      expect(mockFn).toHaveBeenCalledWith(StopParam.NoStopping.toString(), "5", "json", 3);
     });
   });
 
   describe("isPickup", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("ispickup"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが2になる
-      expect(mockFn).toHaveBeenCalledWith(null, 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     test("if isPickup = true", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("ispickup"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["ispickup", "gzip", "out"]);
 
       const result = await NarouAPI.search().isPickup().execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(BooleanNumber.True.toString(), 3);
+      expect(mockFn).toHaveBeenCalledWith(BooleanNumber.True.toString(), "5", "json", 3);
     });
 
     test("if isPickup = false", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("ispickup"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["ispickup", "gzip", "out"]);
 
       const result = await NarouAPI.search().isPickup(false).execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(BooleanNumber.False.toString(), 3);
+      expect(mockFn).toHaveBeenCalledWith(BooleanNumber.False.toString(), "5", "json", 3);
     });
   });
 
   describe("lastUpdate", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("lastup"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが2になる
-      expect(mockFn).toHaveBeenCalledWith(null, 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     test.each([
@@ -1769,22 +1045,12 @@ describe("SearchBuilder", () => {
       [100, 1000],
     ])("if lastUpdate = %i-%i", async (min, max) => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("lastup"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["lastup", "gzip", "out"]);
 
       const result = await NarouAPI.search().lastUpdate(min, max).execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(`${min}-${max}`, 3);
+      expect(mockFn).toHaveBeenCalledWith(`${min}-${max}`, "5", "json", 3);
     });
 
     test.each([
@@ -1793,24 +1059,15 @@ describe("SearchBuilder", () => {
       [new Date(2021, 1, 20), new Date(2021, 1, 30)],
     ])("if lastUpdate = %s-%s", async (min, max) => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("lastup"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["lastup", "gzip", "out"]);
 
       const result = await NarouAPI.search().lastUpdate(min, max).execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
-      // MEMO: unixtimeに変換する
       expect(mockFn).toHaveBeenCalledWith(
-        `${min.getTime() / 1000}-${max.getTime() / 1000}`,
+        `${Math.floor(min.getTime() / 1000)}-${Math.floor(max.getTime() / 1000)}`,
+        "5",
+        "json",
         3
       );
     });
@@ -1819,22 +1076,12 @@ describe("SearchBuilder", () => {
   describe("lastNovelUpdate", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("lastupdate"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipがついているのでsizeが2になる
-      expect(mockFn).toHaveBeenCalledWith(null, 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     test.each([
@@ -1843,24 +1090,14 @@ describe("SearchBuilder", () => {
       [100, 1000],
     ])("if lastNovelUpdate = %i-%i", async (min, max) => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("lastupdate"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["lastupdate", "gzip", "out"]);
 
       const result = await NarouAPI.search()
         .lastNovelUpdate(min, max)
         .execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(`${min}-${max}`, 3);
+      expect(mockFn).toHaveBeenCalledWith(`${min}-${max}`, "5", "json", 3);
     });
 
     test.each([
@@ -1869,26 +1106,17 @@ describe("SearchBuilder", () => {
       [new Date(2021, 1, 20), new Date(2021, 1, 30)],
     ])("if lastNovelUpdate = %s-%s", async (min, max) => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("lastupdate"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["lastupdate", "gzip", "out"]);
 
       const result = await NarouAPI.search()
         .lastNovelUpdate(min, max)
         .execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipがついているのでsizeが3になる
-      // MEMO: unixtimeに変換する
       expect(mockFn).toHaveBeenCalledWith(
-        `${min.getTime() / 1000}-${max.getTime() / 1000}`,
+        `${Math.floor(min.getTime() / 1000)}-${Math.floor(max.getTime() / 1000)}`,
+        "5",
+        "json",
         3
       );
     });
@@ -1897,465 +1125,261 @@ describe("SearchBuilder", () => {
   describe("bigGenre", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("biggenre"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipがついているのでsizeが2になる
-      expect(mockFn).toHaveBeenCalledWith(null, 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     test.each(Object.values(BigGenre))("if bigGenre = %i", async (bigGenre) => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("biggenre"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["biggenre", "gzip", "out"]);
 
       const result = await NarouAPI.search().bigGenre(bigGenre).execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(bigGenre.toString(), 3);
+      expect(mockFn).toHaveBeenCalledWith(bigGenre.toString(), "5", "json", 3);
     });
 
     test("if bigGenre = `1-2-3`", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 3 }];
-          mockFn(url.searchParams.get("biggenre"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["biggenre", "gzip", "out"]);
 
       const result = await NarouAPI.search()
         .bigGenre([BigGenre.Renai, BigGenre.Fantasy, BigGenre.Bungei])
         .execute();
-      expect(result.allcount).toBe(3);
+      expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith("1-2-3", 3);
+      expect(mockFn).toHaveBeenCalledWith("1-2-3", "5", "json", 3);
     });
   });
 
   describe("notBigGenre", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("notbiggenre"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipがついているのでsizeが2になる
-      expect(mockFn).toHaveBeenCalledWith(null, 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     test.each(Object.values(BigGenre))(
       "if notBigGenre = %i",
       async (notBigGenre) => {
         const mockFn = vi.fn();
-        server.use(
-          http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-            const url = new URL(request.url);
-            const response = [{ allcount: 1 }];
-            mockFn(url.searchParams.get("notbiggenre"), url.searchParams.size);
-
-            return responseGzipOrJson(response, url);
-          })
-        );
+        setupMockHandler(mockFn, ["notbiggenre", "gzip", "out"]);
 
         const result = await NarouAPI.search()
           .notBigGenre(notBigGenre)
           .execute();
         expect(result.allcount).toBe(1);
         expect(mockFn).toHaveBeenCalledTimes(1);
-        // MEMO: gzipがついているのでsizeが3になる
-        expect(mockFn).toHaveBeenCalledWith(notBigGenre.toString(), 3);
+        expect(mockFn).toHaveBeenCalledWith(notBigGenre.toString(), "5", "json", 3);
       }
     );
 
     test("if notBigGenre = `1-2-3`", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 3 }];
-          mockFn(url.searchParams.get("notbiggenre"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["notbiggenre", "gzip", "out"]);
 
       const result = await NarouAPI.search()
         .notBigGenre([BigGenre.Renai, BigGenre.Fantasy, BigGenre.Bungei])
         .execute();
-      expect(result.allcount).toBe(3);
+      expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith("1-2-3", 3);
+      expect(mockFn).toHaveBeenCalledWith("1-2-3", "5", "json", 3);
     });
   });
 
   describe("genre", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("genre"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipがついているのでsizeが2になる
-      expect(mockFn).toHaveBeenCalledWith(null, 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     test.each(Object.values(Genre))("if genre = %i", async (genre) => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("genre"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["genre", "gzip", "out"]);
 
       const result = await NarouAPI.search().genre(genre).execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(genre.toString(), 3);
+      expect(mockFn).toHaveBeenCalledWith(genre.toString(), "5", "json", 3);
     });
 
     test("if genre = `201-202-9801`", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 3 }];
-          mockFn(url.searchParams.get("genre"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["genre", "gzip", "out"]);
 
       const result = await NarouAPI.search()
         .genre([Genre.FantasyHigh, Genre.FantasyLow, Genre.NonGenre])
         .execute();
-      expect(result.allcount).toBe(3);
+      expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith("201-202-9801", 3);
+      expect(mockFn).toHaveBeenCalledWith("201-202-9801", "5", "json", 3);
     });
   });
 
   describe("notGenre", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("notgenre"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipがついているのでsizeが2になる
-      expect(mockFn).toHaveBeenCalledWith(null, 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     test.each(Object.values(Genre))("if notGenre = %i", async (notGenre) => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("notgenre"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["notgenre", "gzip", "out"]);
 
       const result = await NarouAPI.search().notGenre(notGenre).execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(notGenre.toString(), 3);
+      expect(mockFn).toHaveBeenCalledWith(notGenre.toString(), "5", "json", 3);
     });
 
     test("if notGenre = `201-202-9801`", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 3 }];
-          mockFn(url.searchParams.get("notgenre"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["notgenre", "gzip", "out"]);
 
       const result = await NarouAPI.search()
         .notGenre([Genre.FantasyHigh, Genre.FantasyLow, Genre.NonGenre])
         .execute();
-      expect(result.allcount).toBe(3);
+      expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith("201-202-9801", 3);
+      expect(mockFn).toHaveBeenCalledWith("201-202-9801", "5", "json", 3);
     });
   });
 
   describe("userId", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("userid"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipがついているのでsizeが2になる
-      expect(mockFn).toHaveBeenCalledWith(null, 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     test.each([1234, 5678, 9012])("if userId = %s", async (userId) => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("userid"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["userid", "gzip", "out"]);
 
       const result = await NarouAPI.search().userId(userId).execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(userId.toString(), 3);
+      expect(mockFn).toHaveBeenCalledWith(userId.toString(), "5", "json", 3);
     });
 
     test("if userId = `1234-5678-9012`", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 3 }];
-          mockFn(url.searchParams.get("userid"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["userid", "gzip", "out"]);
 
       const result = await NarouAPI.search()
         .userId([1234, 5678, 9012])
         .execute();
-      expect(result.allcount).toBe(3);
+      expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith("1234-5678-9012", 3);
+      expect(mockFn).toHaveBeenCalledWith("1234-5678-9012", "5", "json", 3);
     });
   });
 
   describe("isR15", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("isr15"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipがついているのでsizeが2になる
-      expect(mockFn).toHaveBeenCalledWith(null, 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     test("if isR15 = true", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("isr15"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["isr15", "gzip", "out"]);
 
       const result = await NarouAPI.search().isR15().execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(BooleanNumber.True.toString(), 3);
+      expect(mockFn).toHaveBeenCalledWith(BooleanNumber.True.toString(), "5", "json", 3);
     });
 
     test("if isR15 = false", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("notr15"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["notr15", "gzip", "out"]);
 
       const result = await NarouAPI.search().isR15(false).execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(BooleanNumber.True.toString(), 3);
+      expect(mockFn).toHaveBeenCalledWith(BooleanNumber.True.toString(), "5", "json", 3);
     });
   });
 
   describe("fields", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("of"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       const result = await NarouAPI.search().execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      expect(mockFn).toHaveBeenCalledWith(null, 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     test.each(Object.values(Fields))("if fields = %s", async (field) => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("of"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["of", "gzip", "out"]);
 
       const result = await NarouAPI.search().fields(field).execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      expect(mockFn).toHaveBeenCalledWith(field, 3);
+      expect(mockFn).toHaveBeenCalledWith(field, "5", "json", 3);
     });
 
     test("if fields = `ncode-genre`", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("of"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["of", "gzip", "out"]);
 
       const result = await NarouAPI.search()
         .fields([Fields.ncode, Fields.genre])
         .execute();
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
-      expect(mockFn).toHaveBeenCalledWith(`${Fields.ncode}-${Fields.genre}`, 3);
+      expect(mockFn).toHaveBeenCalledWith(`${Fields.ncode}-${Fields.genre}`, "5", "json", 3);
     });
   });
 
   describe("opt", () => {
     test("default", async () => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }];
-
-          mockFn(url.searchParams.get("opt"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["gzip", "out"]);
 
       await NarouAPI.search().execute();
       expect(mockFn).toHaveBeenCalledTimes(1);
-      expect(mockFn).toHaveBeenCalledWith(null, 2);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
     });
 
     test.each([OptionalFields.weekly_unique])("if opt = %s", async (opt) => {
       const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-          const response = [{ allcount: 1 }];
-
-          mockFn(url.searchParams.get("opt"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
+      setupMockHandler(mockFn, ["opt", "gzip", "out"]);
 
       await NarouAPI.search().opt(opt).execute();
       expect(mockFn).toHaveBeenCalledTimes(1);
-      expect(mockFn).toHaveBeenCalledWith(opt, 3);
+      expect(mockFn).toHaveBeenCalledWith(opt, "5", "json", 3);
     });
   });
 });


### PR DESCRIPTION
This pull request introduces a comprehensive set of unit tests for the `SearchBuilderR18` functionality in the `NarouAPI` library. The tests ensure the correctness of various methods and configurations, including the handling of parameters such as `r18Site`, `xid`, `fields`, and `opt`. Additionally, a mock server is set up to simulate API responses, improving the reliability of the tests.

### Added Unit Tests for `SearchBuilderR18`:

* **Test Setup and Mock Server:**
  - Configured a mock server using `msw` to simulate API responses for `SearchBuilderR18` tests. This includes a reusable `setupMockHandler` function to validate query parameters and return mock responses. (`[test/search-builder-r18.test.tsR1-R217](diffhunk://#diff-a04b24d38b289a5744832f0edbb247f72621f20029ff6901ff82356fc1a0c3f0R1-R217)`)

* **Testing `execute` Method:**
  - Added tests to verify that the `execute` method correctly calls the API and processes the response, including validation of the `allcount` and `ncode` fields. (`[test/search-builder-r18.test.tsR1-R217](diffhunk://#diff-a04b24d38b289a5744832f0edbb247f72621f20029ff6901ff82356fc1a0c3f0R1-R217)`)

* **Parameter Handling:**
  - **`r18Site`:** Verified behavior for default, single, and multiple values of the `r18Site` parameter. (`[test/search-builder-r18.test.tsR1-R217](diffhunk://#diff-a04b24d38b289a5744832f0edbb247f72621f20029ff6901ff82356fc1a0c3f0R1-R217)`)
  - **`xid`:** Tested default, single, and multiple values for the `xid` parameter. (`[test/search-builder-r18.test.tsR1-R217](diffhunk://#diff-a04b24d38b289a5744832f0edbb247f72621f20029ff6901ff82356fc1a0c3f0R1-R217)`)
  - **`fields`:** Ensured correct handling of default and specified fields, including combinations of