### PR TITLE
SearchParamsのispickupプロパティをBooleanNumber.Trueに変更し、isPickupメソッドを修正

### DIFF
--- a/src/params.ts
+++ b/src/params.ts
@@ -105,7 +105,7 @@ export interface SearchParams extends ParamsBaseWithOrder<Order> {
 
   stop?: StopParam;
 
-  ispickup?: BooleanNumber;
+  ispickup?: typeof BooleanNumber.True;
   lastup?: string;
   lastupdate?: string;
 

--- a/src/search-builder.ts
+++ b/src/search-builder.ts
@@ -338,8 +338,8 @@ export abstract class NovelSearchBuilderBase<
    *
    * @return {SearchBuilder} this
    */
-  isPickup(bool = true): this {
-    this.set({ ispickup: bool ? BooleanNumber.True : BooleanNumber.False });
+  isPickup(): this {
+    this.set({ ispickup: BooleanNumber.True });
     return this;
   }
 

--- a/test/search-builder.test.ts
+++ b/test/search-builder.test.ts
@@ -1016,6 +1016,7 @@ describe("SearchBuilder", () => {
       expect(mockFn).toHaveBeenCalledTimes(1);
       expect(mockFn).toHaveBeenCalledWith(BooleanNumber.True.toString(), "5", "json", 3);
     });
+  });
 
   describe("lastUpdate", () => {
     test("default", async () => {

--- a/test/search-builder.test.ts
+++ b/test/search-builder.test.ts
@@ -1701,7 +1701,7 @@ describe("SearchBuilder", () => {
       expect(mockFn).toHaveBeenCalledWith(null, 2);
     });
 
-    test("if isPickup = true", async () => {
+    test("if isPickup", async () => {
       const mockFn = vi.fn();
       server.use(
         http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
@@ -1720,27 +1720,6 @@ describe("SearchBuilder", () => {
       // MEMO: gzipとoutがついているのでsizeが3になる
       expect(mockFn).toHaveBeenCalledWith(BooleanNumber.True.toString(), 3);
     });
-
-    test("if isPickup = false", async () => {
-      const mockFn = vi.fn();
-      server.use(
-        http.get("https://api.syosetu.com/novelapi/api/", ({ request }) => {
-          const url = new URL(request.url);
-
-          const response = [{ allcount: 1 }];
-          mockFn(url.searchParams.get("ispickup"), url.searchParams.size);
-
-          return responseGzipOrJson(response, url);
-        })
-      );
-
-      const result = await NarouAPI.search().isPickup(false).execute();
-      expect(result.allcount).toBe(1);
-      expect(mockFn).toHaveBeenCalledTimes(1);
-      // MEMO: gzipとoutがついているのでsizeが3になる
-      expect(mockFn).toHaveBeenCalledWith(BooleanNumber.False.toString(), 3);
-    });
-  });
 
   describe("lastUpdate", () => {
     test("default", async () => {


### PR DESCRIPTION
This pull request refines the handling of the `ispickup` parameter in the search functionality by enforcing stricter type constraints and simplifying the `isPickup` method. The changes ensure that `ispickup` can only be set to `BooleanNumber.True`, improving type safety and reducing ambiguity.

### Type Safety Improvements:
* [`src/params.ts`](diffhunk://#diff-381f8fd6189a58e041b6d54910f2df317e133ef2d25707a5dbc3768e205eef49L108-R108): Updated the `ispickup` parameter in the `SearchParams` interface to only allow the value `BooleanNumber.True` instead of any boolean-like number.

### Code Simplification:
* [`src/search-builder.ts`](diffhunk://#diff-cd4cb878103fc7cfc0345cd16e6d81d2de9c0e3939d9e6cbc5780b64aad3824cL341-R342): Simplified the `isPickup` method in the `NovelSearchBuilderBase` class to always set `ispickup` to `BooleanNumber.True`, removing the optional boolean argument.