### PR TITLE
ユーザー検索機能を修正

### DIFF
--- a/src/narou-search-results.ts
+++ b/src/narou-search-results.ts
@@ -8,6 +8,7 @@ import type {
   R18Fields,
   OptionalFields,
   UserFields,
+  UserSearchParams,
 } from "./params.js";
 
 /**
@@ -45,7 +46,7 @@ export default class NarouSearchResults<T, TKey extends keyof T> {
    */
   constructor(
     [header, ...result]: [{ allcount: number }, ...Pick<T, TKey>[]],
-    params: SearchParams
+    params: SearchParams | UserSearchParams
   ) {
     const count = header.allcount;
     const limit = params.lim ?? 20;

--- a/src/narou.ts
+++ b/src/narou.ts
@@ -112,6 +112,9 @@ export default abstract class NarouNovel {
   async executeUserSearch<T extends keyof UserSearchResult>(
     params: UserSearchParams
   ): Promise<NarouSearchResults<UserSearchResult, T>> {
-    return await this.execute(params, "https://api.syosetu.com/userapi/api/");
+    return new NarouSearchResults<UserSearchResult, T>(
+      await this.execute(params, "https://api.syosetu.com/userapi/api/"),
+      params
+    );
   }
 }

--- a/test/narou.test.ts
+++ b/test/narou.test.ts
@@ -1,4 +1,4 @@
-import NarouAPI, { Fields, RankingType } from "../src";
+import NarouAPI, { Fields, R18Fields, RankingType, UserFields } from "../src";
 import { describe, it, expect, vi } from "vitest";
 
 // MEMO: このファイルのテストは外部APIを利用するため、結果が変わる可能性がある。
@@ -29,7 +29,30 @@ describe("narou-test", () => {
       expect(result.length).toBe(1);
       expect(result.values).toHaveLength(1);
     });
-    // TODO: pageのテストを書く
+  });
+  describe("searchR18", () => {
+    it("if limit = 1 then length = 1", async () => {
+      const result = await NarouAPI.searchR18()
+        .limit(1)
+        .fields([R18Fields.ncode])
+        .execute();
+      expect(result.allcount).toBeGreaterThan(1);
+      expect(result.limit).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+    });
+  });
+  describe("searchUser", () => {
+    it("if limit = 1 then length = 1", async () => {
+      const result = await NarouAPI.searchUser()
+        .limit(1)
+        .fields([UserFields.userid])
+        .execute();
+      expect(result.allcount).toBeGreaterThan(1);
+      expect(result.limit).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+    });
   });
   describe("ranking", () => {
     // 2020/02/01のランキングをテスト

--- a/test/user-search.test.ts
+++ b/test/user-search.test.ts
@@ -1,0 +1,479 @@
+import {
+  beforeAll,
+  afterAll,
+  afterEach,
+  describe,
+  test,
+  expect,
+  vi,
+} from "vitest";
+import { setupServer } from "msw/node";
+import { responseGzipOrJson } from "./mock";
+import NarouAPI, {
+  UserFields,
+  UserOrder,
+} from "../src";
+import { http } from "msw";
+
+const server = setupServer();
+
+const setupMockHandler = (
+  mockFn: (...args: unknown[]) => void,
+  watchParams: string[] = ["out"]
+) => {
+  server.use(
+    http.get("https://api.syosetu.com/userapi/api/", ({ request }) => {
+      const url = new URL(request.url);
+      const params = url.searchParams;
+      const response = [{ allcount: 1 }, { userid: 1234, name: "テストユーザー" }];
+
+      const values = watchParams.map((param) => params.get(param));
+      mockFn(...values, params.size);
+
+      return responseGzipOrJson(response, url);
+    })
+  );
+};
+
+describe("UserSearchBuilder", () => {
+  beforeAll(() => server.listen());
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+
+  describe("gzip", () => {
+    test("default", async () => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["gzip", "out"]);
+      const result = await NarouAPI.searchUser().execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].userid).toBe(1234);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
+    });
+
+    test("if gzip = 0", async () => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["out"]);
+
+      const result = await NarouAPI.searchUser().gzip(0).execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].userid).toBe(1234);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith("json", 1);
+    });
+
+    test.each([1, 2, 3, 4, 5] as const)("if gzip = %i", async (gzip) => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["gzip", "out"]);
+
+      const result = await NarouAPI.searchUser().gzip(gzip).execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].userid).toBe(1234);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(gzip.toString(), "json", 2);
+    });
+  });
+
+  describe("limit", () => {
+    test("default", async () => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["gzip", "out"]);
+
+      const result = await NarouAPI.searchUser().execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].userid).toBe(1234);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
+    });
+
+    test.each([1, 10, 100, 500] as const)("if limit = %i", async (limit) => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["lim", "gzip", "out"]);
+
+      const result = await NarouAPI.searchUser().limit(limit).execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].userid).toBe(1234);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(limit.toString(), "5", "json", 3);
+    });
+  });
+
+  describe("start", () => {
+    test("default", async () => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["gzip", "out"]);
+
+      const result = await NarouAPI.searchUser().execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].userid).toBe(1234);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
+    });
+
+    test.each([1, 10, 100, 500] as const)("if start = %i", async (start) => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["st", "gzip", "out"]);
+
+      const result = await NarouAPI.searchUser().start(start).execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].userid).toBe(1234);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(start.toString(), "5", "json", 3);
+    });
+  });
+
+  describe("page", () => {
+    describe("default count", () => {
+      test.each([1, 2, 3, 4, 5] as const)("if page = %i", async (page) => {
+        const mockFn = vi.fn();
+        setupMockHandler(mockFn, ["lim", "st", "gzip", "out"]);
+
+        const result = await NarouAPI.searchUser().page(page).execute();
+        expect(result.allcount).toBe(1);
+        expect(result.length).toBe(1);
+        expect(result.values).toHaveLength(1);
+        expect(result.values[0].userid).toBe(1234);
+        expect(mockFn).toHaveBeenCalledTimes(1);
+        expect(mockFn).toHaveBeenCalledWith(
+          "20",
+          (page * 20).toString(),
+          "5",
+          "json",
+          4
+        );
+      });
+    });
+
+    describe.each([1, 10, 100, 500] as const)("if count = %i", (count) => {
+      test.each([1, 2, 3, 4, 5] as const)("if page = %i", async (page) => {
+        const mockFn = vi.fn();
+        setupMockHandler(mockFn, ["lim", "st", "gzip", "out"]);
+
+        const result = await NarouAPI.searchUser().page(page, count).execute();
+        expect(result.allcount).toBe(1);
+        expect(result.length).toBe(1);
+        expect(result.values).toHaveLength(1);
+        expect(result.values[0].userid).toBe(1234);
+        expect(mockFn).toHaveBeenCalledTimes(1);
+        expect(mockFn).toHaveBeenCalledWith(
+          count.toString(),
+          (page * count).toString(),
+          "5",
+          "json",
+          4
+        );
+      });
+    });
+  });
+
+  describe("order", () => {
+    test("default", async () => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["gzip", "out"]);
+
+      const result = await NarouAPI.searchUser().execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].userid).toBe(1234);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
+    });
+
+    describe.each(Object.values(UserOrder))("if order = %s", (order) => {
+      test(order, async () => {
+        const mockFn = vi.fn();
+        setupMockHandler(mockFn, ["order", "gzip", "out"]);
+
+        const result = await NarouAPI.searchUser().order(order).execute();
+        expect(result.allcount).toBe(1);
+        expect(result.length).toBe(1);
+        expect(result.values).toHaveLength(1);
+        expect(result.values[0].userid).toBe(1234);
+        expect(mockFn).toHaveBeenCalledTimes(1);
+        expect(mockFn).toHaveBeenCalledWith(order, "5", "json", 3);
+      });
+    });
+  });
+
+  describe("word", () => {
+    test("default", async () => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["gzip", "out"]);
+
+      const result = await NarouAPI.searchUser().execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].userid).toBe(1234);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
+    });
+
+    test.each(["test", "テストユーザー", "1234", "あいう"])("if word = %s", async (word) => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["word", "gzip", "out"]);
+
+      const result = await NarouAPI.searchUser().word(word).execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].userid).toBe(1234);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(word, "5", "json", 3);
+    });
+  });
+
+  describe("notWord", () => {
+    test("default", async () => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["gzip", "out"]);
+
+      const result = await NarouAPI.searchUser().execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].userid).toBe(1234);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
+    });
+
+    test.each(["test", "テストユーザー", "1234", "あいう"])("if notWord = %s", async (word) => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["notword", "gzip", "out"]);
+
+      const result = await NarouAPI.searchUser().notWord(word).execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].userid).toBe(1234);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(word, "5", "json", 3);
+    });
+  });
+
+  describe("userId", () => {
+    test("default", async () => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["gzip", "out"]);
+
+      const result = await NarouAPI.searchUser().execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].userid).toBe(1234);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
+    });
+
+    test.each([1234, 5678, 9012])("if userId = %i", async (userId) => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["userid", "gzip", "out"]);
+
+      const result = await NarouAPI.searchUser().userId(userId).execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].userid).toBe(1234);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(userId.toString(), "5", "json", 3);
+    });
+  });
+
+  describe("name1st", () => {
+    test("default", async () => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["gzip", "out"]);
+
+      const result = await NarouAPI.searchUser().execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].userid).toBe(1234);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
+    });
+
+    test.each(["あ", "い", "う", "え", "お"])("if name1st = %s", async (name1st) => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["name1st", "gzip", "out"]);
+
+      const result = await NarouAPI.searchUser().name1st(name1st).execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].userid).toBe(1234);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(name1st, "5", "json", 3);
+    });
+  });
+
+  describe("minNovel", () => {
+    test("default", async () => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["gzip", "out"]);
+
+      const result = await NarouAPI.searchUser().execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].userid).toBe(1234);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
+    });
+
+    test.each([1, 10, 100])("if minNovel = %i", async (minNovel) => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["minnovel", "gzip", "out"]);
+
+      const result = await NarouAPI.searchUser().minNovel(minNovel).execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].userid).toBe(1234);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(minNovel.toString(), "5", "json", 3);
+    });
+  });
+
+  describe("maxNovel", () => {
+    test("default", async () => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["gzip", "out"]);
+
+      const result = await NarouAPI.searchUser().execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].userid).toBe(1234);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
+    });
+
+    test.each([10, 100, 1000])("if maxNovel = %i", async (maxNovel) => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["maxnovel", "gzip", "out"]);
+
+      const result = await NarouAPI.searchUser().maxNovel(maxNovel).execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].userid).toBe(1234);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(maxNovel.toString(), "5", "json", 3);
+    });
+  });
+
+  describe("minReview", () => {
+    test("default", async () => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["gzip", "out"]);
+
+      const result = await NarouAPI.searchUser().execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].userid).toBe(1234);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
+    });
+
+    test.each([1, 10, 100])("if minReview = %i", async (minReview) => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["minreview", "gzip", "out"]);
+
+      const result = await NarouAPI.searchUser().minReview(minReview).execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].userid).toBe(1234);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(minReview.toString(), "5", "json", 3);
+    });
+  });
+
+  describe("maxReview", () => {
+    test("default", async () => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["gzip", "out"]);
+
+      const result = await NarouAPI.searchUser().execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].userid).toBe(1234);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
+    });
+
+    test.each([10, 100, 1000])("if maxReview = %i", async (maxReview) => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["maxreview", "gzip", "out"]);
+
+      const result = await NarouAPI.searchUser().maxReview(maxReview).execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].userid).toBe(1234);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(maxReview.toString(), "5", "json", 3);
+    });
+  });
+
+  describe("fields", () => {
+    test("default", async () => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["gzip", "out"]);
+
+      const result = await NarouAPI.searchUser().execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].userid).toBe(1234);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith("5", "json", 2);
+    });
+
+    test.each(Object.values(UserFields))("if fields = %s", async (field) => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["of", "gzip", "out"]);
+
+      const result = await NarouAPI.searchUser().fields(field).execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].userid).toBe(1234);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(field, "5", "json", 3);
+    });
+
+    test("if fields = `userid-name`", async () => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["of", "gzip", "out"]);
+
+      const result = await NarouAPI.searchUser()
+        .fields([UserFields.userid, UserFields.name])
+        .execute();
+      expect(result.allcount).toBe(1);
+      expect(result.length).toBe(1);
+      expect(result.values).toHaveLength(1);
+      expect(result.values[0].userid).toBe(1234);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(`${UserFields.userid}-${UserFields.name}`, "5", "json", 3);
+    });
+  });
+});


### PR DESCRIPTION
This pull request introduces support for user-specific searches in the `NarouAPI` and adds corresponding test cases. Key changes include updates to the `NarouSearchResults` and `NarouNovel` classes to handle `UserSearchParams`, as well as new tests for `searchUser` functionality.

### Enhancements to user search functionality:

* [`src/narou-search-results.ts`](diffhunk://#diff-d4d196a5e4d8880ec5477d15ab88dc2b6977fcbf39c97ffbeb9530ed428f2142R11): Updated the `NarouSearchResults` constructor to accept `SearchParams | UserSearchParams`, enabling the handling of user-specific search parameters. Added `UserSearchParams` to the imports. [[1]](diffhunk://#diff-d4d196a5e4d8880ec5477d15ab88dc2b6977fcbf39c97ffbeb9530ed428f2142R11) [[2]](diffhunk://#diff-d4d196a5e4d8880ec5477d15ab88dc2b6977fcbf39c97ffbeb9530ed428f2142L48-R49)
* [`src/narou.ts`](diffhunk://#diff-52396954ffdd69579bb9859723c70cb3dc2dc9d71dbeef34ad95487cbaf99878L115-R118): Modified the `executeUserSearch` method in the `NarouNovel` class to return a `NarouSearchResults` instance, ensuring consistency with other search methods.

### Test coverage improvements:

* [`test/narou.test.ts`](diffhunk://#diff-4893c52de5c084cdcff245c25ff84ad06d507295599da42e082ae80c7ac29da4L1-R1): Added test cases for the `searchUser` method to validate functionality, including checks for result length and parameter handling. Also added a test for `searchR18` as part of broader test coverage enhancements. Updated imports to include `R18Fields` and `UserFields`. [[1]](diffhunk://#diff-4893c52de5c084cdcff245c25ff84ad06d507295599da42e082ae80c7ac29da4L1-R1) [[2]](diffhunk://#diff-4893c52de5c084cdcff245c25ff84ad06d507295599da42e082ae80c7ac29da4L32-R55)