### PR TITLE
テストを追加

### DIFF
--- a/test/narou-fetch.test.ts
+++ b/test/narou-fetch.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, afterEach, beforeAll, afterAll } from 'vitest';
+import NarouNovelFetch from '../src/narou-fetch';
+import { setupServer } from 'msw/node';
+import { http } from 'msw';
+import { responseGzipOrJson } from './mock';
+
+// テスト用データ
+const mockData = [{ test: 'data' }];
+
+// MSWサーバーをセットアップ
+const server = setupServer();
+
+describe('NarouNovelFetch', () => {
+  beforeAll(() => server.listen());
+  afterEach(() => {
+    vi.resetAllMocks();
+    server.resetHandlers();
+  });
+  afterAll(() => server.close());
+
+  it('should use unzipp for gzipped data', async () => {
+    // MSWでエンドポイントをモック
+    server.use(
+      http.get('https://api.example.com', ({ request }) => {
+        const url = new URL(request.url);
+        expect(url.searchParams.get('gzip')).toBe('5');
+        return responseGzipOrJson(mockData, url);
+      })
+    );
+
+    const narouFetch = new NarouNovelFetch();
+
+    // @ts-expect-error - Accessing protected method for testing
+    const result = await narouFetch.execute({ gzip: 5 }, 'https://api.example.com');
+
+    // 解凍されたデータが元のデータと一致することを確認
+    expect(result).toEqual(mockData);
+  });
+
+  it('should return json directly when gzip is 0', async () => {
+    // MSWでエンドポイントをモック
+    server.use(
+      http.get('https://api.example.com', ({ request }) => {
+        const url = new URL(request.url);
+        // gzipパラメータがないことを確認
+        expect(url.searchParams.has('gzip')).toBe(false);
+        return responseGzipOrJson(mockData, url);
+      })
+    );
+
+    const narouFetch = new NarouNovelFetch();
+
+    // @ts-expect-error - Accessing protected method for testing
+    const result = await narouFetch.execute({ gzip: 0 }, 'https://api.example.com');
+
+    expect(result).toEqual(mockData);
+  });
+
+  it('should delete gzip parameter when set to 0', async () => {
+    // URLパラメータをキャプチャするモック
+    const requestSpy = vi.fn();
+
+    server.use(
+      http.get('https://api.example.com', ({ request }) => {
+        const url = new URL(request.url);
+        // gzipパラメータがないことを確認
+        expect(url.searchParams.has('gzip')).toBe(false);
+        requestSpy();
+        return responseGzipOrJson(mockData, url);
+      })
+    );
+
+    const narouFetch = new NarouNovelFetch();
+
+    // @ts-expect-error - Accessing protected method for testing
+    await narouFetch.execute({ gzip: 0 }, 'https://api.example.com');
+
+    // リクエストが呼ばれたことを確認
+    expect(requestSpy).toHaveBeenCalled();
+  });
+
+  it('should use custom fetch function when provided', async () => {
+    // カスタムフェッチ関数をモック
+    const customFetchMock = vi.fn().mockResolvedValue({
+      json: vi.fn().mockResolvedValue(mockData)
+    });
+
+    const narouFetch = new NarouNovelFetch(customFetchMock);
+
+    // @ts-expect-error - Accessing protected method for testing
+    const result = await narouFetch.execute({ gzip: 0 }, 'https://api.example.com');
+
+    // カスタムフェッチ関数が呼ばれたことを確認
+    expect(customFetchMock).toHaveBeenCalled();
+    expect(result).toEqual(mockData);
+  });
+
+  it('should set gzip to 5 when undefined', async () => {
+    // URLパラメータをキャプチャするモック
+    const requestSpy = vi.fn();
+
+    server.use(
+      http.get('https://api.example.com', ({ request }) => {
+        const url = new URL(request.url);
+        // gzipパラメータが5であることを確認
+        expect(url.searchParams.get('gzip')).toBe('5');
+        requestSpy();
+        return responseGzipOrJson(mockData, url);
+      })
+    );
+
+    const narouFetch = new NarouNovelFetch();
+
+    // @ts-expect-error - Accessing protected method for testing
+    await narouFetch.execute({}, 'https://api.example.com');
+
+    // リクエストが呼ばれたことを確認
+    expect(requestSpy).toHaveBeenCalled();
+  });
+
+  it('should append all parameters to URL', async () => {
+    // URLパラメータをキャプチャするモック
+    const requestSpy = vi.fn();
+
+    server.use(
+      http.get('https://api.example.com', ({ request }) => {
+        const url = new URL(request.url);
+        // URLパラメータをチェック
+        expect(url.searchParams.get('word')).toBe('test');
+        expect(url.searchParams.get('order')).toBe('new');
+        expect(url.searchParams.get('out')).toBe('json');
+        requestSpy();
+        return responseGzipOrJson(mockData, url);
+      })
+    );
+
+    const narouFetch = new NarouNovelFetch();
+
+    // @ts-expect-error - Accessing protected method for testing
+    await narouFetch.execute({ word: 'test', order: 'new' }, 'https://api.example.com');
+
+    // リクエストが呼ばれたことを確認
+    expect(requestSpy).toHaveBeenCalled();
+  });
+
+  it('should make proper fetch request to API endpoint', async () => {
+    // URLパラメータをキャプチャするモック
+    const requestSpy = vi.fn();
+
+    server.use(
+      http.get('https://api.example.com', ({ request }) => {
+        const url = new URL(request.url);
+        // URLパラメータをチェック
+        expect(url.searchParams.get('out')).toBe('json');
+        expect(url.searchParams.get('gzip')).toBe('5');
+        requestSpy();
+        return responseGzipOrJson(mockData, url);
+      })
+    );
+
+    const narouFetch = new NarouNovelFetch();
+
+    // @ts-expect-error - Accessing protected method for testing
+    await narouFetch.execute({}, 'https://api.example.com');
+
+    // リクエストが呼ばれたことを確認
+    expect(requestSpy).toHaveBeenCalled();
+  });
+});

--- a/test/narou-jsonp.test.ts
+++ b/test/narou-jsonp.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import NarouNovelJsonp from '../src/narou-jsonp';
+import * as jsonpModule from '../src/util/jsonp';
+import { Order } from '../src';
+
+describe('NarouNovelJsonp', () => {
+  let narouJsonp: NarouNovelJsonp;
+  const mockJsonp = vi.fn();
+
+  beforeEach(() => {
+    narouJsonp = new NarouNovelJsonp();
+    vi.spyOn(jsonpModule, 'jsonp').mockImplementation(mockJsonp);
+    mockJsonp.mockReset();
+  });
+
+  it('should set out parameter to jsonp', async () => {
+    mockJsonp.mockResolvedValue({ result: 'success' });
+    const params = { word: 'test' };
+    const endpoint = 'https://api.syosetu.com/novelapi/api/';
+
+    await (narouJsonp as NarouNovelJsonp & { execute: typeof NarouNovelJsonp.prototype['execute'] }).execute(params, endpoint);
+
+    expect(mockJsonp).toHaveBeenCalledWith(expect.stringContaining('out=jsonp'));
+  });
+
+  it('should set gzip parameter to 0', async () => {
+    mockJsonp.mockResolvedValue({ result: 'success' });
+    const params = { word: 'test' };
+    const endpoint = 'https://api.syosetu.com/novelapi/api/';
+
+    await (narouJsonp as NarouNovelJsonp & { execute: typeof NarouNovelJsonp.prototype['execute'] }).execute(params, endpoint);
+
+    expect(mockJsonp).toHaveBeenCalledWith(expect.stringContaining('gzip=0'));
+  });
+
+  it('should append all parameters to the URL', async () => {
+    mockJsonp.mockResolvedValue({ result: 'success' });
+    const params = { word: 'test', order: Order.DailyPoint, limit: 20 };
+    const endpoint = 'https://api.syosetu.com/novelapi/api/';
+
+    await (narouJsonp as NarouNovelJsonp & { execute: typeof NarouNovelJsonp.prototype['execute'] }).execute(params, endpoint);
+
+    const url = mockJsonp.mock.calls[0][0];
+    expect(url).toContain('word=test');
+    expect(url).toContain(`order=${Order.DailyPoint}`);
+    expect(url).toContain('limit=20');
+  });
+
+  it('should ignore undefined parameters', async () => {
+    mockJsonp.mockResolvedValue({ result: 'success' });
+    const params = { word: 'test', order: undefined };
+    const endpoint = 'https://api.syosetu.com/novelapi/api/';
+
+    await (narouJsonp as NarouNovelJsonp & { execute: typeof NarouNovelJsonp.prototype['execute'] }).execute(params, endpoint);
+
+    const url = mockJsonp.mock.calls[0][0];
+    expect(url).toContain('word=test');
+    expect(url).not.toContain('order=');
+  });
+
+  it('should return the result from jsonp', async () => {
+    const mockResult = { result: 'success', data: [{ id: 1 }] };
+    mockJsonp.mockResolvedValue(mockResult);
+    const params = { word: 'test' };
+    const endpoint = 'https://api.syosetu.com/novelapi/api/';
+
+    const result = await (narouJsonp as NarouNovelJsonp & { execute: typeof NarouNovelJsonp.prototype['execute'] }).execute(params, endpoint);
+
+
+    expect(result).toEqual(mockResult);
+  });
+});

--- a/test/narou-search-results.test.ts
+++ b/test/narou-search-results.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import NarouSearchResults from '../src/narou-search-results';
+import type { SearchParams } from '../src/params.js';
+
+describe('NarouSearchResults', () => {
+  interface MockData {
+    id: number;
+    title: string;
+    author: string;
+  }
+
+  it('should correctly initialize with default params', () => {
+    const header = { allcount: 100 };
+    const data: Pick<MockData, 'id' | 'title'>[] = [
+      { id: 1, title: 'Test Novel 1' },
+      { id: 2, title: 'Test Novel 2' },
+    ];
+    const params: SearchParams = {};
+
+    const results = new NarouSearchResults<MockData, 'id' | 'title'>([header, ...data], params);
+
+    expect(results.allcount).toBe(100);
+    expect(results.limit).toBe(20); // Default limit
+    expect(results.start).toBe(0); // Default start
+    expect(results.page).toBe(0); // 0/20 = 0
+    expect(results.length).toBe(2);
+    expect(results.values).toEqual(data);
+  });
+
+  it('should correctly initialize with custom params', () => {
+    const header = { allcount: 500 };
+    const data: Pick<MockData, 'id' | 'author'>[] = [
+      { id: 1, author: 'Author 1' },
+      { id: 2, author: 'Author 2' },
+      { id: 3, author: 'Author 3' },
+    ];
+    const params: SearchParams = {
+      lim: 10,
+      st: 20
+    };
+
+    const results = new NarouSearchResults<MockData, 'id' | 'author'>([header, ...data], params);
+
+    expect(results.allcount).toBe(500);
+    expect(results.limit).toBe(10);
+    expect(results.start).toBe(20);
+    expect(results.page).toBe(2); // 20/10 = 2
+    expect(results.length).toBe(3);
+    expect(results.values).toEqual(data);
+  });
+
+  it('should handle empty results', () => {
+    const header = { allcount: 0 };
+    const data: Pick<MockData, 'id'>[] = [];
+    const params: SearchParams = {
+      lim: 30,
+      st: 0
+    };
+
+    const results = new NarouSearchResults<MockData, 'id'>([header, ...data], params);
+
+    expect(results.allcount).toBe(0);
+    expect(results.limit).toBe(30);
+    expect(results.start).toBe(0);
+    expect(results.page).toBe(0);
+    expect(results.length).toBe(0);
+    expect(results.values).toEqual([]);
+  });
+});

--- a/test/ranking-history.test.ts
+++ b/test/ranking-history.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { formatRankingHistory } from '../src/ranking-history.js';
+import { RankingType } from '../src/params.js';
+import { parse } from 'date-fns';
+
+describe('formatRankingHistory', () => {
+  it('should format raw ranking history data correctly', () => {
+    const input = {
+      rtype: '20230101-d',
+      pt: 100,
+      rank: 5
+    } as const;
+
+    const result = formatRankingHistory(input);
+
+    expect(result).toEqual({
+      type: 'd' as RankingType,
+      date: parse('20230101', 'yyyyMMdd', new Date()),
+      pt: 100,
+      rank: 5
+    });
+  });
+
+  it('should handle different ranking types', () => {
+    const input = {
+      rtype: '20230215-w',
+      pt: 500,
+      rank: 1
+    } as const;
+
+    const result = formatRankingHistory(input);
+
+    expect(result).toEqual({
+      type: 'w' as RankingType,
+      date: parse('20230215', 'yyyyMMdd', new Date()),
+      pt: 500,
+      rank: 1
+    });
+  });
+
+  it('should handle different date formats correctly', () => {
+    const input = {
+      rtype: '20221231-m',
+      pt: 250,
+      rank: 10
+    } as const;
+
+    const result = formatRankingHistory(input);
+
+    expect(result).toEqual({
+      type: 'm' as RankingType,
+      date: parse('20221231', 'yyyyMMdd', new Date()),
+      pt: 250,
+      rank: 10
+    });
+  });
+  
+  it('should handle quarter ranking type', () => {
+    const input = {
+      rtype: '20240331-q',
+      pt: 1000,
+      rank: 3
+    } as const;
+
+    const result = formatRankingHistory(input);
+
+    expect(result).toEqual({
+      type: 'q' as RankingType,
+      date: parse('20240331', 'yyyyMMdd', new Date()),
+      pt: 1000,
+      rank: 3
+    });
+  });
+});

--- a/test/util/jsonp.test.ts
+++ b/test/util/jsonp.test.ts
@@ -1,0 +1,204 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { jsonp } from '../../src/util/jsonp';
+
+// グローバルなモックの作成
+interface MockWindow {
+  [key: string]: unknown;
+}
+const mockWindow: MockWindow = {};
+global.window = mockWindow as unknown as Window & typeof globalThis;
+// Create a type for accessing window with dynamic string keys
+declare global {
+  interface Window {
+    [key: string]: unknown;
+  }
+}
+
+// グローバルなdocumentモックの作成
+interface MockDocument {
+  createElement: ReturnType<typeof vi.fn>;
+  getElementsByTagName: ReturnType<typeof vi.fn>;
+  head: object;
+}
+
+const mockDocument: MockDocument = {
+  createElement: vi.fn(),
+  getElementsByTagName: vi.fn(),
+  head: {}
+};
+global.document = mockDocument as unknown as Document;
+
+interface MockScript {
+  setAttribute: ReturnType<typeof vi.fn>;
+  parentNode: MockParentNode | null;
+}
+
+interface MockParentNode {
+  insertBefore: ReturnType<typeof vi.fn>;
+  removeChild: ReturnType<typeof vi.fn>;
+}
+
+interface MockHead {
+  insertBefore: ReturnType<typeof vi.fn>;
+}
+
+describe('jsonp', () => {
+  let mockScript: MockScript;
+  let mockHead: MockHead;
+  let mockParentNode: MockParentNode;
+  let mockUrl: string;
+
+  beforeEach(() => {
+    // Reset DOM mocks
+    mockScript = {
+      setAttribute: vi.fn((name, value) => {
+        if (name === 'src') {
+          mockUrl = value;
+        }
+      }),
+      parentNode: null,
+    };
+
+    mockParentNode = {
+      insertBefore: vi.fn(),
+      removeChild: vi.fn(),
+    };
+
+    mockHead = {
+      insertBefore: vi.fn(),
+    };
+
+    // Mock document methods
+    document.createElement = vi.fn().mockImplementation(() => mockScript);
+    document.getElementsByTagName = vi.fn().mockImplementation(() => ({
+      item: vi.fn().mockReturnValue({
+        parentNode: mockParentNode
+      })
+    }));
+
+    // Mock document.head
+    Object.defineProperty(document, 'head', {
+      value: mockHead,
+      configurable: true
+    });
+
+    // Mock setTimeout
+    vi.useFakeTimers();
+
+    // Clear global object of any previous callback functions
+    Object.keys(window).forEach(key => {
+      if (key.startsWith('__jp') || key.startsWith('custom')) {
+        delete window[key];
+      }
+    });
+
+    mockUrl = '';
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  test('should create a script tag with the correct URL', async () => {
+    const url = 'https://example.com/api';
+
+    // Create a promise that will resolve when the JSONP callback is triggered
+    const jsonpPromise = jsonp(url);
+
+    // Check if the script was created
+    expect(document.createElement).toHaveBeenCalledWith('script');
+
+    // mockScriptにsetAttributeが呼ばれたことを確認
+    expect(mockScript.setAttribute).toHaveBeenCalled();
+
+    // mockUrlからコールバック名を抽出
+    const match = mockUrl.match(/callback=(__jp\d+)/);
+    expect(match).not.toBeNull();
+
+    const callbackName = match![1];
+    expect(callbackName).toMatch(/^__jp\d+$/);
+
+    // コールバック関数が登録されているか確認
+    expect(typeof window[callbackName]).toBe('function');
+
+    // Simulate JSONP callback with mock data
+    const mockData = { result: 'success' };
+    (window[callbackName] as (data: unknown) => void)(mockData);
+
+    // Check results
+    const result = await jsonpPromise;
+    expect(result).toEqual(mockData);
+    expect(mockParentNode.insertBefore).toHaveBeenCalledWith(mockScript, expect.anything());
+  });
+
+  test('should apply custom options', async () => {
+    const url = 'https://example.com/api';
+    const options = {
+      prefix: 'custom',
+      param: 'cb',
+      timeout: 5000
+    };
+
+    const jsonpPromise = jsonp(url, options);
+
+    // mockScriptにsetAttributeが呼ばれたことを確認
+    expect(mockScript.setAttribute).toHaveBeenCalled();
+
+    // mockUrlからコールバック名を抽出 - カスタムパラメータ名を使用
+    const match = mockUrl.match(new RegExp(`${options.param}=(${options.prefix}\\d+)`));
+    expect(match).not.toBeNull();
+
+    const callbackName = match![1];
+    expect(callbackName).toMatch(new RegExp(`^${options.prefix}\\d+$`));
+
+    // コールバック関数が登録されているか確認
+    expect(typeof window[callbackName]).toBe('function');
+
+    // Trigger callback
+    const mockData = { custom: true };
+    (window[callbackName] as (data: unknown) => void)(mockData);
+
+    const result = await jsonpPromise;
+    expect(result).toEqual(mockData);
+  });
+
+  test('should timeout and reject the promise', async () => {
+    const url = 'https://example.com/api';
+    const options = { timeout: 1000 };
+
+    const promise = jsonp(url, options);
+
+    // Advance timers to trigger timeout
+    vi.advanceTimersByTime(1001);
+
+    await expect(promise).rejects.toThrow('Timeout');
+  });
+
+  test('should use document.head if no script tags exist', async () => {
+    document.getElementsByTagName = vi.fn().mockImplementation(() => ({
+      item: vi.fn().mockReturnValue(null)
+    }));
+
+    const url = 'https://example.com/api';
+    const jsonpPromise = jsonp(url);
+
+    // mockScriptにsetAttributeが呼ばれたことを確認
+    expect(mockScript.setAttribute).toHaveBeenCalled();
+
+    // mockUrlからコールバック名を抽出
+    const match = mockUrl.match(/callback=(__jp\d+)/);
+    expect(match).not.toBeNull();
+
+    const callbackName = match![1];
+
+    // コールバック関数が登録されているか確認
+    expect(typeof window[callbackName]).toBe('function');
+
+    // Trigger callback
+    (window[callbackName] as (data: unknown) => void)({ success: true });
+
+    await jsonpPromise;
+    expect(mockHead.insertBefore).toHaveBeenCalledWith(mockScript, null);
+  });
+});

--- a/test/util/unzipp.test.ts
+++ b/test/util/unzipp.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { unzipp } from '../../src/util/unzipp';
+import { gzip } from 'zlib';
+import { promisify } from 'util';
+
+// 非同期gzip関数の作成
+const gzipAsync = promisify(gzip);
+
+describe('unzipp', () => {
+  it('正常なJSONデータを解凍して解析できること', async () => {
+    // テスト用のJSONデータ
+    const testData = { key: 'value', test: 123 };
+    const jsonString = JSON.stringify(testData);
+    
+    // 実際にgzipで圧縮
+    const compressedData = await gzipAsync(Buffer.from(jsonString));
+    
+    // unzipp関数でデータを解凍・解析
+    const result = await unzipp(compressedData);
+    
+    // 結果を検証
+    expect(result).toEqual(testData);
+  });
+
+  it('JSON解析に失敗した場合は解凍されたデータをスローすること', async () => {
+    // 有効なJSONではないデータ
+    const invalidJson = 'This is not a valid JSON';
+    
+    // 実際にgzipで圧縮
+    const compressedData = await gzipAsync(Buffer.from(invalidJson));
+    
+    // unzipp関数の呼び出し（エラーが発生することを期待）
+    await expect(unzipp(compressedData)).rejects.toBe(invalidJson);
+  });
+
+  it('解凍できないデータの場合は元のデータの文字列表現をスローすること', async () => {
+    // 圧縮されていないデータ（解凍しようとするとエラーになる）
+    const notCompressed = new TextEncoder().encode('Not compressed data');
+    
+    // unzipp関数の呼び出し（エラーが発生することを期待）
+    await expect(unzipp(notCompressed)).rejects.toMatch(/Not compressed data/);
+  });
+});


### PR DESCRIPTION
This pull request adds comprehensive unit tests for various modules in the project, ensuring robust validation of functionality and edge cases. The changes include tests for API fetch utilities, JSONP handling, ranking history formatting, search results processing, and gzip decompression.

### Tests for API Fetch Utilities
* Added tests for `NarouNovelFetch` to validate handling of gzip parameters, custom fetch functions, and URL parameter appending. (`test/narou-fetch.test.ts`, [test/narou-fetch.test.tsR1-R169](diffhunk://#diff-7ebb1e0622cbf2d2bcb2782a10a879bee5701aff68bbab84ad186562d5c133aaR1-R169))
* Added tests for `NarouNovelJsonp` to ensure proper parameter handling, including ignoring undefined parameters and appending all valid parameters to the URL. (`test/narou-jsonp.test.ts`, [test/narou-jsonp.test.tsR1-R72](diffhunk://#diff-86eb4e275437df568f415505f6f8e676fd43d1ef3eeab3ad9beb2d3a1a48f7e5R1-R72))

### Tests for Data Processing
* Added tests for `NarouSearchResults` to validate initialization with default and custom parameters, and handling of empty results. (`test/narou-search-results.test.ts`, [test/narou-search-results.test.tsR1-R69](diffhunk://#diff-cd236c474f0a427d1210689e642da4be67aad6c85bde27f4bbed8dd9af6640c2R1-R69))
* Added tests for `formatRankingHistory` to ensure correct formatting of ranking history data, including different ranking types and date formats. (`test/ranking-history.test.ts`, [test/ranking-history.test.tsR1-R74](diffhunk://#diff-d1e0621753071acba4ce6c480179fa73a542c6cb33b2169503911441605074a5R1-R74))

### Tests for Utility Functions
* Added tests for `jsonp` to validate script tag creation, custom options, timeout handling, and fallback to `document.head` when no script tags exist. (`test/util/jsonp.test.ts`, [test/util/jsonp.test.tsR1-R204](diffhunk://#diff-c7868bd11d3b6e0bd737ccece3268e0b67931819d1cdd2bae2670ee9245bab09R1-R204))
* Added tests for `unzipp` to verify correct decompression of valid JSON data, handling of invalid JSON, and errors for non-compressed input. (`test/util/unzipp.test.ts`, [test/util/unzipp.test.tsR1-R43](diffhunk://#diff-b3bd81a0a9bdc8354ef52b4203a33583be9b7a260ca75250b5f1ecf70eccf218R1-R43))