### PR TITLE
Remove date fns

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,14 +63,12 @@
     "docs:clean": "pnpm dlx rimraf docs",
     "docs:typedoc": "pnpm dlx typedoc --out ./docs src/index.ts"
   },
-  "dependencies": {
-    "date-fns": "^4.1.0"
-  },
   "devDependencies": {
     "@types/node": "^22.15.3",
     "@typescript-eslint/eslint-plugin": "^8.31.1",
     "@typescript-eslint/parser": "^8.31.1",
     "@vitest/coverage-v8": "^3.1.2",
+    "date-fns": "^4.1.0",
     "eslint": "^9.25.1",
     "eslint-config-prettier": "^10.1.2",
     "eslint-plugin-prettier": "^5.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      date-fns:
-        specifier: ^4.1.0
-        version: 4.1.0
     devDependencies:
       '@types/node':
         specifier: ^22.15.3
@@ -24,6 +20,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^3.1.2
         version: 3.1.2(vitest@3.1.2(@types/node@22.15.3)(msw@2.7.5(@types/node@22.15.3)(typescript@5.8.3)))
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
       eslint:
         specifier: ^9.25.1
         version: 9.25.1

--- a/src/ranking-history.ts
+++ b/src/ranking-history.ts
@@ -1,7 +1,5 @@
-import { parse } from "date-fns";
 import type { RankingType } from "./params.js";
-
-const dateFormat = "yyyyMMdd";
+import { parseDate } from "./util/date.js";
 
 export interface RankingHistoryRawResult {
   rtype: `${string}-${RankingType}`;
@@ -16,12 +14,23 @@ export interface RankingHistoryResult {
   rank: number;
 }
 
+/**
+ * 生のランキング履歴エントリを構造化された形式にフォーマットします。
+ * 
+ * @param rankin - フォーマットする生のランキング履歴データ
+ * @returns 日付とタイプが解析されたフォーマット済みランキング履歴
+ * 
+ * @example
+ * const rawData = { rtype: "20230101-daily", pt: 500, rank: 10 };
+ * const formattedData = formatRankingHistory(rawData);
+ * // 返り値: { type: "daily", date: [Dateオブジェクト], pt: 500, rank: 10 }
+ */
 export function formatRankingHistory(
   rankin: RankingHistoryRawResult
 ): RankingHistoryResult {
   const { rtype, pt, rank } = rankin;
   const [_date, _type] = rtype.split("-");
-  const date = parse(_date, dateFormat, new Date());
+  const date = parseDate(_date);
   const type = _type as RankingType;
 
   return { type, date, pt, rank };

--- a/src/ranking.ts
+++ b/src/ranking.ts
@@ -1,7 +1,6 @@
 import type { NarouRankingResult, RankingResult } from "./narou-ranking-results.js";
 import SearchBuilder from "./search-builder.js";
 import type { DefaultSearchResultFields } from "./search-builder.js";
-import { addDays, format } from "date-fns";
 import type {
   GzipLevel,
   OptionalFields,
@@ -13,8 +12,7 @@ import {
 } from "./params.js";
 import type NarouNovel from "./narou.js";
 import type { SearchResultFields } from "./narou-search-results.js";
-
-const dateFormat = "yyyyMMdd";
+import { addDays, formatDate } from "./util/date.js";
 
 /**
  * なろう小説ランキングAPIのヘルパークラス。
@@ -52,7 +50,7 @@ export default class RankingBuilder {
      * クエリパラメータ
      * @protected
      */
-    this.date$ = addDays(Date.now(), -1);
+    this.date$ = addDays(new Date(), -1);
     this.type$ = RankingType.Daily;
   }
 
@@ -114,7 +112,7 @@ export default class RankingBuilder {
    * @see https://dev.syosetu.com/man/rankapi/#output
    */
   execute(): Promise<NarouRankingResult[]> {
-    const date = format(this.date$, dateFormat);
+    const date = formatDate(this.date$);
     this.set({ rtype: `${date}-${this.type$}` });
     return this.api.executeRanking(this.params as RankingParams);
   }

--- a/src/util/date.ts
+++ b/src/util/date.ts
@@ -1,0 +1,38 @@
+// 日付関連のユーティリティ関数
+
+/**
+ * 文字列の日付（yyyyMMdd形式）をDateオブジェクトに変換する
+ * @param dateStr yyyyMMdd形式の日付文字列
+ * @returns Dateオブジェクト
+ */
+export function parseDate(dateStr: string): Date {
+  const year = parseInt(dateStr.substring(0, 4), 10);
+  const month = parseInt(dateStr.substring(4, 6), 10) - 1; // JavaScriptの月は0から始まる
+  const day = parseInt(dateStr.substring(6, 8), 10);
+
+  return new Date(year, month, day, 0, 0, 0, 0);
+}
+
+/**
+ * 日付をyyyyMMdd形式の文字列に変換する
+ * @param date 日付
+ * @returns yyyyMMdd形式の文字列
+ */
+export function formatDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}${month}${day}`;
+}
+
+/**
+ * 指定された日数を加算した新しい日付を返す
+ * @param date 元の日付
+ * @param days 加算する日数
+ * @returns 新しい日付
+ */
+export function addDays(date: Date, days: number): Date {
+  const result = new Date(date);
+  result.setDate(result.getDate() + days);
+  return result;
+}

--- a/test/util/date.test.ts
+++ b/test/util/date.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { parseDate, formatDate, addDays } from '../../src/util/date';
+import { format, isEqual, addDays as dateAdd } from 'date-fns';
+
+describe('parseDate', () => {
+  const testCases = [
+    { input: '20230101', expected: new Date(2023, 0, 1), description: '新年' },
+    { input: '20240229', expected: new Date(2024, 1, 29), description: 'うるう年' },
+    { input: '20230228', expected: new Date(2023, 1, 28), description: '非うるう年の2月' },
+    { input: '20231231', expected: new Date(2023, 11, 31), description: '年末' },
+    { input: '20230401', expected: new Date(2023, 3, 1), description: '4月1日' },
+    { input: '20230930', expected: new Date(2023, 8, 30), description: '9月末' },
+    { input: '20220501', expected: new Date(2022, 4, 1), description: '過去の日付' },
+    { input: '20300615', expected: new Date(2030, 5, 15), description: '未来の日付' },
+  ];
+
+  it.each(testCases)('$description: "$input" を正しく解析する', ({ input, expected }) => {
+    const result = parseDate(input);
+    expect(isEqual(result, expected)).toBe(true);
+    expect(format(result, 'yyyy-MM-dd')).toBe(format(expected, 'yyyy-MM-dd'));
+  });
+
+  it('時刻コンポーネントが0に設定されることを確認する', () => {
+    const result = parseDate('20230101');
+    expect(format(result, 'HH:mm:ss.SSS')).toBe('00:00:00.000');
+  });
+});
+
+describe('formatDate', () => {
+  const testCases = [
+    { input: new Date(2023, 0, 1), expected: '20230101', description: '新年' },
+    { input: new Date(2024, 1, 29), expected: '20240229', description: 'うるう年' },
+    { input: new Date(2023, 1, 28), expected: '20230228', description: '非うるう年の2月' },
+    { input: new Date(2023, 11, 31), expected: '20231231', description: '年末' },
+    { input: new Date(2023, 3, 1), expected: '20230401', description: '4月1日' },
+    { input: new Date(2023, 8, 30), expected: '20230930', description: '9月末' },
+    { input: new Date(2023, 0, 9), expected: '20230109', description: '1桁の日（パディング）' },
+    { input: new Date(2023, 5, 5), expected: '20230605', description: '1桁の月（パディング）' },
+    { input: new Date(2023, 5, 7), expected: '20230607', description: '1桁の月・日（パディング）' },
+  ];
+
+  it.each(testCases)('$description: $input を "$expected" にフォーマットする', ({ input, expected }) => {
+    const result = formatDate(input);
+    expect(result).toBe(expected);
+  });
+});
+
+describe('addDays', () => {
+  const testCases = [
+    { base: new Date(2023, 0, 1), days: 5, expected: new Date(2023, 0, 6), description: '通常の加算' },
+    { base: new Date(2023, 0, 31), days: 1, expected: new Date(2023, 1, 1), description: '月をまたぐ加算' },
+    { base: new Date(2023, 1, 1), days: -2, expected: new Date(2023, 0, 30), description: '負の日数の加算' },
+    { base: new Date(2023, 11, 31), days: 1, expected: new Date(2024, 0, 1), description: '年をまたぐ加算' },
+    { base: new Date(2024, 1, 28), days: 1, expected: new Date(2024, 1, 29), description: 'うるう年の加算' },
+    { base: new Date(2023, 1, 28), days: 1, expected: new Date(2023, 2, 1), description: '非うるう年の加算' },
+    { base: new Date(2023, 5, 30), days: 31, expected: new Date(2023, 6, 31), description: '複数月をまたぐ加算' },
+    { base: new Date(2023, 0, 15), days: 0, expected: new Date(2023, 0, 15), description: '0日の加算（変化なし）' },
+    { base: new Date(2023, 0, 1), days: 365, expected: new Date(2024, 0, 1), description: '1年の加算' },
+  ];
+
+  it.each(testCases)('$description: $base に $days 日を加算すると $expected になる', ({ base, days, expected }) => {
+    const result = addDays(base, days);
+    const dateAddResult = dateAdd(new Date(base), days);
+    expect(isEqual(result, expected)).toBe(true);
+    expect(isEqual(result, dateAddResult)).toBe(true);
+    expect(format(result, 'yyyy-MM-dd')).toBe(format(expected, 'yyyy-MM-dd'));
+  });
+});


### PR DESCRIPTION
This pull request refactors date-related functionality by replacing the `date-fns` library with custom utility functions, reducing dependency overhead and improving maintainability. It also includes comprehensive unit tests for the new utility functions. Below are the key changes grouped by theme:

### Dependency Management

* Removed `date-fns` from `dependencies` in `package.json` and `pnpm-lock.yaml` and added it to `devDependencies` for testing purposes. (`[[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L66-R71)`, `[[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL10-L13)`, `[[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR23-R25)`)

### Date Utility Functions

* Introduced a new `src/util/date.ts` file with utility functions: `parseDate`, `formatDate`, and `addDays`. These functions replace `date-fns` methods for parsing, formatting, and manipulating dates. (`[src/util/date.tsR1-R38](diffhunk://#diff-0d95ffecb21f6e2a23345be08dfcb5c628e39103a4d37aa0a492879af9512466R1-R38)`)

### Code Refactoring

* Replaced `date-fns` methods (`parse`, `format`, and `addDays`) with the new utility functions in `src/ranking-history.ts` and `src/ranking.ts`. (`[[1]](diffhunk://#diff-815821e61dbafd7327d1f2f1c286c6054457bb69bad4b66db51ae4b6a9877046L1-R2)`, `[[2]](diffhunk://#diff-815821e61dbafd7327d1f2f1c286c6054457bb69bad4b66db51ae4b6a9877046R17-R33)`, `[[3]](diffhunk://#diff-5bfd795de271d621f912a0764dfa4a5bc6db712e881e8da64aae67dfe39cb704L4)`, `[[4]](diffhunk://#diff-5bfd795de271d621f912a0764dfa4a5bc6db712e881e8da64aae67dfe39cb704L16-R15)`, `[[5]](diffhunk://#diff-5bfd795de271d621f912a0764dfa4a5bc6db712e881e8da64aae67dfe39cb704L55-R53)`, `[[6]](diffhunk://#diff-5bfd795de271d621f912a0764dfa4a5bc6db712e881e8da64aae67dfe39cb704L117-R115)`)

### Unit Testing

* Added `test/util/date.test.ts` to thoroughly test the new date utility functions (`parseDate`, `formatDate`, and `addDays`) with diverse scenarios, including edge cases like leap years and date transitions across months and years. (`[test/util/date.test.tsR1-R68](diffhunk://#diff-f85008c2b92caf17e1c59eef0acf971daf51aa4c4f809b64e232c9ed19b86e90R1-R68)`)