### PR TITLE
setup-nodeのリポジトリURLを追加

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -17,7 +17,8 @@ jobs:
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: "lts/*"
-          cache: 'pnpm'
+          cache: "pnpm"
+          repository-url: https://registry.npmjs.org/
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
This pull request updates the `.github/workflows/publish-npm.yml` file to enhance the configuration for Node.js and package management. The most important change is the addition of the `repository-url` field to the `setup-node` action configuration.

Workflow configuration improvements:

* [`.github/workflows/publish-npm.yml`](diffhunk://#diff-f089b0e55b389f533faf1e65e3cb93b0bcd97b391c32f28449d08fd4f0512447L20-R21): Added the `repository-url` field to specify the NPM registry URL (`https://registry.npmjs.org/`) in the `setup-node` action, ensuring proper registry configuration during the workflow execution.