### PR TITLE
registry-urlのキー名を修正

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: "lts/*"
           cache: "pnpm"
-          repository-url: https://registry.npmjs.org/
+          registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/publish-npm.yml` file. The change updates the `repository-url` key to `registry-url` in the workflow configuration to align with the correct naming convention.