### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nodejs-test.yml
+++ b/.github/workflows/nodejs-test.yml
@@ -1,4 +1,6 @@
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/deflis/node-narou/security/code-scanning/2](https://github.com/deflis/node-narou/security/code-scanning/2)

To fix the vulnerability, an explicit `permissions:` block should be added to the workflow to restrict the permissions granted to the GITHUB_TOKEN. As the workflow appears to do only code checkout, install dependencies, build, run test, and report coverage (with no steps that require write access like pushing commits, releases, or issues), the minimal required permission is likely `contents: read`. The safest fix is to add a `permissions:` block at the root of the workflow (directly beneath `name:` and above `on:`) with `contents: read`. If the coverage report step ever needs additional permissions (for example, uploading to a PR or creating comments), this may be expanded accordingly, but unless documented, it should start with minimal permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
