### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,4 +1,6 @@
 name: Publish Package to npmjs
+permissions:
+  contents: read
 on:
   release:
     types: [published]


### PR DESCRIPTION
Potential fix for [https://github.com/deflis/node-narou/security/code-scanning/1](https://github.com/deflis/node-narou/security/code-scanning/1)

To fix this issue, explicitly set a `permissions` key at the top (`root`) level of the workflow (just underneath `name:` and above `on:`) to restrict the `GITHUB_TOKEN`'s default permissions to the minimum necessary. In most npm publish workflows, unless you are updating the repo or releases or creating pull requests, only `contents: read` is necessary (in fact, sometimes zero permissions works, but that can break some `actions/checkout` versions, so `contents: read` is preferred as a safe and minimal default). This ensures the principle of least privilege is adhered to.

**Specifically:**  
- Add a `permissions:` block with `contents: read` at the top of `.github/workflows/publish-npm.yml`.
- No imports or external changes are required; this is a YAML configuration matter.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
