### PR TITLE
feat: allow object format for range parameters

### DIFF
--- a/src/search-builder.ts
+++ b/src/search-builder.ts
@@ -21,7 +21,7 @@ import type {
   DateParam,
 } from "./params.js";
 import { BooleanNumber, StopParam } from "./params.js";
-import type { Join } from "./util/type.js";
+import type { Join, RangeParam } from "./util/type.js";
 
 export type DefaultSearchResultFields = keyof Omit<
   NarouSearchResult,
@@ -52,6 +52,26 @@ export abstract class SearchBuilderBase<
    */
   protected static distinct<T>(array: readonly T[]): T[] {
     return Array.from(new Set(array));
+  }
+
+  /**
+   * 範囲指定や配列をハイフン区切りの文字列に変換する
+   * @protected
+   * @static
+   * @param n 範囲指定オブジェクト、数値の配列、あるいは単一の数値
+   * @returns ハイフン区切りの文字列
+   */
+  protected static range2string<T extends number>(
+    n: T | readonly T[] | RangeParam<T>
+  ): Join<T | ""> {
+    if (typeof n === "object" && n !== null && !Array.isArray(n)) {
+      const obj = n as Extract<RangeParam<T>, object>;
+      if ("equal" in obj) {
+        return obj.equal.toString() as Join<T>;
+      }
+      return `${obj.min ?? ""}-${obj.max ?? ""}` as Join<T | "">;
+    }
+    return SearchBuilderBase.array2string(n) as Join<T>;
   }
 
   /**
@@ -294,11 +314,12 @@ export abstract class NovelSearchBuilderBase<
   /**
    * 抽出する作品の文字数を指定します (length)。
    * 範囲指定する場合は、最小文字数と最大文字数をハイフン(-)記号で区切ってください。
-   * @param length 文字数、または[最小文字数, 最大文字数]
+   * オブジェクトによる指定 ({ min?: number, max?: number } または { equal: number }) も可能です。
+   * @param length 文字数、または[最小文字数, 最大文字数]、またはオブジェクト指定
    * @return {this}
    */
-  length(length: number | readonly number[]): this {
-    this.set({ length: NovelSearchBuilderBase.array2string(length) });
+  length(length: number | readonly number[] | RangeParam<number>): this {
+    this.set({ length: NovelSearchBuilderBase.range2string(length) });
     return this;
   }
 
@@ -315,8 +336,20 @@ export abstract class NovelSearchBuilderBase<
    * @return {this}
    */
   kaiwaritu(min: number, max: number): this;
+  /**
+   * 抽出する作品の会話率を%単位で範囲指定またはオブジェクトで指定します (kaiwaritu)。
+   * @param range 範囲指定オブジェクト
+   * @return {this}
+   */
+  kaiwaritu(range: RangeParam<number>): this;
 
-  kaiwaritu(min: number, max?: number): this {
+  kaiwaritu(minOrRange: number | RangeParam<number>, max?: number): this {
+    if (typeof minOrRange === "object" && minOrRange !== null) {
+      this.set({ kaiwaritu: NovelSearchBuilderBase.range2string(minOrRange) });
+      return this;
+    }
+
+    const min = minOrRange;
     let n: number | string;
     if (max != null) {
       n = `${min}-${max}`;
@@ -329,21 +362,23 @@ export abstract class NovelSearchBuilderBase<
 
   /**
    * 抽出する作品の挿絵数を指定します (sasie)。
-   * @param num 挿絵数、または[最小挿絵数, 最大挿絵数]
+   * オブジェクトによる指定 ({ min?: number, max?: number } または { equal: number }) も可能です。
+   * @param num 挿絵数、または[最小挿絵数, 最大挿絵数]、またはオブジェクト指定
    * @return {this}
    */
-  sasie(num: number | readonly number[]): this {
-    this.set({ sasie: NovelSearchBuilderBase.array2string(num) });
+  sasie(num: number | readonly number[] | RangeParam<number>): this {
+    this.set({ sasie: NovelSearchBuilderBase.range2string(num) });
     return this;
   }
 
   /**
    * 抽出する作品の予想読了時間を分単位で指定します (time)。
-   * @param num 読了時間(分)、または[最小読了時間, 最大読了時間]
+   * オブジェクトによる指定 ({ min?: number, max?: number } または { equal: number }) も可能です。
+   * @param num 読了時間(分)、または[最小読了時間, 最大読了時間]、またはオブジェクト指定
    * @return {this}
    */
-  time(num: number | readonly number[]): this {
-    this.set({ time: NovelSearchBuilderBase.array2string(num) });
+  time(num: number | readonly number[] | RangeParam<number>): this {
+    this.set({ time: NovelSearchBuilderBase.range2string(num) });
     return this;
   }
 

--- a/src/search-builder.ts
+++ b/src/search-builder.ts
@@ -62,7 +62,7 @@ export abstract class SearchBuilderBase<
    * @returns ハイフン区切りの文字列
    */
   protected static range2string<T extends number>(
-    n: T | readonly T[] | RangeParam<T>
+    n: T | readonly [T, T] | RangeParam<T>
   ): Join<T | ""> | undefined {
     if (typeof n === "object" && n !== null && !Array.isArray(n)) {
       if ("equal" in n && typeof n.equal === "number") {
@@ -75,6 +75,9 @@ export abstract class SearchBuilderBase<
         return `${obj.min ?? ""}-${obj.max ?? ""}` as Join<T | "">;
       }
       return undefined;
+    }
+    if (Array.isArray(n) && n.length > 2) {
+      throw new Error("範囲指定の配列は要素数を2つ以内にする必要があります");
     }
     return SearchBuilderBase.array2string(n) as Join<T>;
   }
@@ -323,7 +326,7 @@ export abstract class NovelSearchBuilderBase<
    * @param length 文字数、または[最小文字数, 最大文字数]、またはオブジェクト指定
    * @return {this}
    */
-  length(length: number | readonly number[] | RangeParam<number>): this {
+  length(length: number | readonly [number, number] | RangeParam<number>): this {
     const val = NovelSearchBuilderBase.range2string(length);
     if (val !== undefined) {
       this.set({ length: val });
@@ -377,7 +380,7 @@ export abstract class NovelSearchBuilderBase<
    * @param num 挿絵数、または[最小挿絵数, 最大挿絵数]、またはオブジェクト指定
    * @return {this}
    */
-  sasie(num: number | readonly number[] | RangeParam<number>): this {
+  sasie(num: number | readonly [number, number] | RangeParam<number>): this {
     const val = NovelSearchBuilderBase.range2string(num);
     if (val !== undefined) {
       this.set({ sasie: val });
@@ -391,7 +394,7 @@ export abstract class NovelSearchBuilderBase<
    * @param num 読了時間(分)、または[最小読了時間, 最大読了時間]、またはオブジェクト指定
    * @return {this}
    */
-  time(num: number | readonly number[] | RangeParam<number>): this {
+  time(num: number | readonly [number, number] | RangeParam<number>): this {
     const val = NovelSearchBuilderBase.range2string(num);
     if (val !== undefined) {
       this.set({ time: val });

--- a/src/search-builder.ts
+++ b/src/search-builder.ts
@@ -63,11 +63,14 @@ export abstract class SearchBuilderBase<
    */
   protected static range2string<T extends number>(
     n: T | readonly T[] | RangeParam<T>
-  ): Join<T | ""> {
+  ): Join<T | ""> | undefined {
     if (typeof n === "object" && n !== null && !Array.isArray(n)) {
       const obj = n as Extract<RangeParam<T>, object>;
       if ("equal" in obj) {
         return obj.equal.toString() as Join<T>;
+      }
+      if (obj.min === undefined && obj.max === undefined) {
+        return undefined;
       }
       return `${obj.min ?? ""}-${obj.max ?? ""}` as Join<T | "">;
     }
@@ -319,7 +322,10 @@ export abstract class NovelSearchBuilderBase<
    * @return {this}
    */
   length(length: number | readonly number[] | RangeParam<number>): this {
-    this.set({ length: NovelSearchBuilderBase.range2string(length) });
+    const val = NovelSearchBuilderBase.range2string(length);
+    if (val !== undefined) {
+      this.set({ length: val });
+    }
     return this;
   }
 
@@ -345,7 +351,10 @@ export abstract class NovelSearchBuilderBase<
 
   kaiwaritu(minOrRange: number | RangeParam<number>, max?: number): this {
     if (typeof minOrRange === "object" && minOrRange !== null) {
-      this.set({ kaiwaritu: NovelSearchBuilderBase.range2string(minOrRange) });
+      const val = NovelSearchBuilderBase.range2string(minOrRange);
+      if (val !== undefined) {
+        this.set({ kaiwaritu: val });
+      }
       return this;
     }
 
@@ -367,7 +376,10 @@ export abstract class NovelSearchBuilderBase<
    * @return {this}
    */
   sasie(num: number | readonly number[] | RangeParam<number>): this {
-    this.set({ sasie: NovelSearchBuilderBase.range2string(num) });
+    const val = NovelSearchBuilderBase.range2string(num);
+    if (val !== undefined) {
+      this.set({ sasie: val });
+    }
     return this;
   }
 
@@ -378,7 +390,10 @@ export abstract class NovelSearchBuilderBase<
    * @return {this}
    */
   time(num: number | readonly number[] | RangeParam<number>): this {
-    this.set({ time: NovelSearchBuilderBase.range2string(num) });
+    const val = NovelSearchBuilderBase.range2string(num);
+    if (val !== undefined) {
+      this.set({ time: val });
+    }
     return this;
   }
 

--- a/src/search-builder.ts
+++ b/src/search-builder.ts
@@ -65,14 +65,16 @@ export abstract class SearchBuilderBase<
     n: T | readonly T[] | RangeParam<T>
   ): Join<T | ""> | undefined {
     if (typeof n === "object" && n !== null && !Array.isArray(n)) {
-      const obj = n as Extract<RangeParam<T>, object>;
-      if ("equal" in obj) {
-        return obj.equal.toString() as Join<T>;
+      if ("equal" in n && typeof n.equal === "number") {
+        return n.equal.toString() as Join<T>;
+      } else if ("min" in n || "max" in n) {
+        const obj = n as Extract<RangeParam<T>, { min?: T, max?: T }>;
+        if (obj.min === undefined && obj.max === undefined) {
+          return undefined;
+        }
+        return `${obj.min ?? ""}-${obj.max ?? ""}` as Join<T | "">;
       }
-      if (obj.min === undefined && obj.max === undefined) {
-        return undefined;
-      }
-      return `${obj.min ?? ""}-${obj.max ?? ""}` as Join<T | "">;
+      return undefined;
     }
     return SearchBuilderBase.array2string(n) as Join<T>;
   }

--- a/src/util/type.ts
+++ b/src/util/type.ts
@@ -24,3 +24,9 @@ type Stringable = string | number | bigint | boolean | null | undefined;
  * type JoinedNumbers = Join<Numbers>; // '1' | '2' | '3' | '1-1' | '1-2' | '1-3' | '2-1' | '2-2' | '2-3' | '3-1' | '3-2' | '3-3'
  */
 export type Join<T extends Stringable> = `${T}-${T}` | `${T}`;
+
+/**
+ * 範囲指定のためのオブジェクトの型。
+ * @template T - 範囲指定する値の型
+ */
+export type RangeParam<T extends number> = { min?: T; max?: T } | { equal: T };

--- a/src/util/type.ts
+++ b/src/util/type.ts
@@ -29,4 +29,7 @@ export type Join<T extends Stringable> = `${T}-${T}` | `${T}`;
  * 範囲指定のためのオブジェクトの型。
  * @template T - 範囲指定する値の型
  */
-export type RangeParam<T extends number> = { min?: T; max?: T } | { equal: T };
+export type RangeParam<T extends number> =
+  | { min: T; max?: T }
+  | { min?: T; max: T }
+  | { equal: T };

--- a/test/search-builder.test.ts
+++ b/test/search-builder.test.ts
@@ -787,6 +787,46 @@ describe("SearchBuilder", () => {
       expect(mockFn).toHaveBeenCalledTimes(1);
       expect(mockFn).toHaveBeenCalledWith(`0-${length}`, "5", "json", 3);
     });
+
+    test("if length = { min: 1000 }", async () => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["length", "gzip", "out"]);
+
+      const result = await NarouAPI.search().length({ min: 1000 }).execute();
+      expect(result.allcount).toBe(1);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(`1000-`, "5", "json", 3);
+    });
+
+    test("if length = { max: 1000 }", async () => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["length", "gzip", "out"]);
+
+      const result = await NarouAPI.search().length({ max: 1000 }).execute();
+      expect(result.allcount).toBe(1);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(`-1000`, "5", "json", 3);
+    });
+
+    test("if length = { min: 100, max: 1000 }", async () => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["length", "gzip", "out"]);
+
+      const result = await NarouAPI.search().length({ min: 100, max: 1000 }).execute();
+      expect(result.allcount).toBe(1);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(`100-1000`, "5", "json", 3);
+    });
+
+    test("if length = { equal: 1000 }", async () => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["length", "gzip", "out"]);
+
+      const result = await NarouAPI.search().length({ equal: 1000 }).execute();
+      expect(result.allcount).toBe(1);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(`1000`, "5", "json", 3);
+    });
   });
 
   describe("kaiwaritu", () => {
@@ -822,6 +862,26 @@ describe("SearchBuilder", () => {
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
       expect(mockFn).toHaveBeenCalledWith(`${min}-${max}`, "5", "json", 3);
+    });
+
+    test("if kaiwaritu = { min: 10 }", async () => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["kaiwaritu", "gzip", "out"]);
+
+      const result = await NarouAPI.search().kaiwaritu({ min: 10 }).execute();
+      expect(result.allcount).toBe(1);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(`10-`, "5", "json", 3);
+    });
+
+    test("if kaiwaritu = { max: 50 }", async () => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["kaiwaritu", "gzip", "out"]);
+
+      const result = await NarouAPI.search().kaiwaritu({ max: 50 }).execute();
+      expect(result.allcount).toBe(1);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(`-50`, "5", "json", 3);
     });
   });
 
@@ -859,6 +919,16 @@ describe("SearchBuilder", () => {
       expect(mockFn).toHaveBeenCalledTimes(1);
       expect(mockFn).toHaveBeenCalledWith(`${min}-${max}`, "5", "json", 3);
     });
+
+    test("if sasie = { min: 5 }", async () => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["sasie", "gzip", "out"]);
+
+      const result = await NarouAPI.search().sasie({ min: 5 }).execute();
+      expect(result.allcount).toBe(1);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(`5-`, "5", "json", 3);
+    });
   });
 
   describe("time", () => {
@@ -894,6 +964,16 @@ describe("SearchBuilder", () => {
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
       expect(mockFn).toHaveBeenCalledWith(`${min}-${max}`, "5", "json", 3);
+    });
+
+    test("if time = { min: 10, max: 20 }", async () => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["time", "gzip", "out"]);
+
+      const result = await NarouAPI.search().time({ min: 10, max: 20 }).execute();
+      expect(result.allcount).toBe(1);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(`10-20`, "5", "json", 3);
     });
   });
 

--- a/test/search-builder.test.ts
+++ b/test/search-builder.test.ts
@@ -929,6 +929,36 @@ describe("SearchBuilder", () => {
       expect(mockFn).toHaveBeenCalledTimes(1);
       expect(mockFn).toHaveBeenCalledWith(`5-`, "5", "json", 3);
     });
+
+    test("if sasie = { max: 10 }", async () => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["sasie", "gzip", "out"]);
+
+      const result = await NarouAPI.search().sasie({ max: 10 }).execute();
+      expect(result.allcount).toBe(1);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(`-10`, "5", "json", 3);
+    });
+
+    test("if sasie = { min: 5, max: 10 }", async () => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["sasie", "gzip", "out"]);
+
+      const result = await NarouAPI.search().sasie({ min: 5, max: 10 }).execute();
+      expect(result.allcount).toBe(1);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(`5-10`, "5", "json", 3);
+    });
+
+    test("if sasie = { equal: 5 }", async () => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["sasie", "gzip", "out"]);
+
+      const result = await NarouAPI.search().sasie({ equal: 5 }).execute();
+      expect(result.allcount).toBe(1);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(`5`, "5", "json", 3);
+    });
   });
 
   describe("time", () => {
@@ -974,6 +1004,36 @@ describe("SearchBuilder", () => {
       expect(result.allcount).toBe(1);
       expect(mockFn).toHaveBeenCalledTimes(1);
       expect(mockFn).toHaveBeenCalledWith(`10-20`, "5", "json", 3);
+    });
+
+    test("if time = { min: 10 }", async () => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["time", "gzip", "out"]);
+
+      const result = await NarouAPI.search().time({ min: 10 }).execute();
+      expect(result.allcount).toBe(1);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(`10-`, "5", "json", 3);
+    });
+
+    test("if time = { max: 20 }", async () => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["time", "gzip", "out"]);
+
+      const result = await NarouAPI.search().time({ max: 20 }).execute();
+      expect(result.allcount).toBe(1);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(`-20`, "5", "json", 3);
+    });
+
+    test("if time = { equal: 10 }", async () => {
+      const mockFn = vi.fn();
+      setupMockHandler(mockFn, ["time", "gzip", "out"]);
+
+      const result = await NarouAPI.search().time({ equal: 10 }).execute();
+      expect(result.allcount).toBe(1);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith(`10`, "5", "json", 3);
     });
   });
 

--- a/test/search-builder.test.ts
+++ b/test/search-builder.test.ts
@@ -920,6 +920,14 @@ describe("SearchBuilder", () => {
       expect(mockFn).toHaveBeenCalledWith(`${min}-${max}`, "5", "json", 3);
     });
 
+    test("if sasie = array > 2 length throws", async () => {
+      const builder = NarouAPI.search();
+      expect(() => {
+        // @ts-expect-error Testing invalid runtime input
+        builder.sasie([1, 2, 3]);
+      }).toThrow("範囲指定の配列は要素数を2つ以内にする必要があります");
+    });
+
     test("if sasie = { min: 5 }", async () => {
       const mockFn = vi.fn();
       setupMockHandler(mockFn, ["sasie", "gzip", "out"]);


### PR DESCRIPTION
This PR introduces the ability to use object formats for setting range-based filter parameters, enhancing readability and developer experience.

Previously, users had to use `[min, max]` tuples and manage omit limits. Now, fields like `length`, `sasie`, `time`, and `kaiwaritu` natively accept objects matching `{ min?: T, max?: T } | { equal: T }`.

### Changes Made:
- Added `RangeParam` type to utility types.
- Enhanced parameter processing inside `NovelSearchBuilderBase` by creating a `range2string` utility which handles parsing the new object shape into the `min-max` format expected by the API.
- Updated typing and overloading for the related parameters (`length`, `sasie`, `time`, and `kaiwaritu`).
- Added robust unit test coverage.

---
*PR created automatically by Jules for task [4859039751617875636](https://jules.google.com/task/4859039751617875636) started by @deflis*